### PR TITLE
refactor: remove duplicate ValidationFieldError and evaluation mapping

### DIFF
--- a/docs/agents/api-contract-hardening.md
+++ b/docs/agents/api-contract-hardening.md
@@ -46,7 +46,8 @@ You are a senior Spring Boot engineer executing a structured fix pass on ReviewF
 | GlobalExceptionHandler | `com.reviewflow.shared.exception.GlobalExceptionHandler` |
 | HttpErrorJsonWriter | `com.reviewflow.infrastructure.security.HttpErrorJsonWriter` |
 | JwtAuthenticationFilter | `com.reviewflow.infrastructure.security.JwtAuthenticationFilter` |
-| ApiResponse | `com.reviewflow.shared.api.ApiResponse` |
+| ApiResponse | `com.reviewflow.shared.exception.ApiResponse` |
+| ValidationFieldError | `com.reviewflow.shared.dto.ValidationFieldError` |
 
 ---
 

--- a/src/main/java/com/reviewflow/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/reviewflow/evaluation/controller/EvaluationController.java
@@ -1,5 +1,6 @@
 package com.reviewflow.evaluation.controller;
 
+import com.reviewflow.evaluation.mapper.EvaluationResponseMapper;
 import com.reviewflow.evaluation.dto.request.CreateEvaluationRequest;
 import com.reviewflow.evaluation.dto.request.PatchCommentRequest;
 import com.reviewflow.evaluation.dto.request.PatchScoreRequest;
@@ -18,10 +19,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -415,61 +414,6 @@ public class EvaluationController {
 
   private EvaluationResponse toResponse(Evaluation ev) {
     List<RubricScore> scores = evaluationService.getRubricScoresForEvaluation(ev.getId());
-    BigDecimal maxPossible =
-        scores.stream()
-            .map(
-                s ->
-                    s.getCriterion() != null && s.getCriterion().getMaxScore() != null
-                        ? BigDecimal.valueOf(s.getCriterion().getMaxScore())
-                        : BigDecimal.ZERO)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
-    return getEvaluationResponse(ev, scores, maxPossible, hashidService);
-  }
-
-  public static EvaluationResponse getEvaluationResponse(
-      Evaluation ev,
-      List<RubricScore> scores,
-      BigDecimal maxPossible,
-      HashidService hashidService) {
-    List<EvaluationResponse.RubricScoreResponse> scoreResponses =
-        scores.stream()
-            .map(
-                s -> {
-                  BigDecimal maxScore =
-                      s.getCriterion() != null && s.getCriterion().getMaxScore() != null
-                          ? BigDecimal.valueOf(s.getCriterion().getMaxScore())
-                          : BigDecimal.ZERO;
-                  return EvaluationResponse.RubricScoreResponse.builder()
-                      .id(hashidService.encode(s.getId()))
-                      .criterionId(
-                          s.getCriterion() != null
-                              ? hashidService.encode(s.getCriterion().getId())
-                              : null)
-                      .criterionName(s.getCriterion() != null ? s.getCriterion().getName() : null)
-                      .maxScore(maxScore)
-                      .score(s.getScore())
-                      .comment(s.getComment())
-                      .build();
-                })
-            .collect(Collectors.toList());
-    return EvaluationResponse.builder()
-        .id(hashidService.encode(ev.getId()))
-        .submissionId(
-            ev.getSubmission() != null ? hashidService.encode(ev.getSubmission().getId()) : null)
-        .instructorId(
-            ev.getInstructor() != null ? hashidService.encode(ev.getInstructor().getId()) : null)
-        .instructorName(
-            ev.getInstructor() != null
-                ? ev.getInstructor().getFirstName() + " " + ev.getInstructor().getLastName()
-                : null)
-        .overallComment(ev.getOverallComment())
-        .totalScore(ev.getTotalScore())
-        .maxPossibleScore(maxPossible)
-        .isDraft(ev.getIsDraft())
-        .publishedAt(ev.getPublishedAt())
-        .createdAt(ev.getCreatedAt())
-        .hasPdf(ev.getPdfPath() != null)
-        .rubricScores(scoreResponses)
-        .build();
+    return EvaluationResponseMapper.toResponse(ev, scores, hashidService);
   }
 }

--- a/src/main/java/com/reviewflow/grading/controller/StudentController.java
+++ b/src/main/java/com/reviewflow/grading/controller/StudentController.java
@@ -1,7 +1,6 @@
 package com.reviewflow.grading.controller;
 
-import static com.reviewflow.evaluation.controller.EvaluationController.getEvaluationResponse;
-
+import com.reviewflow.evaluation.mapper.EvaluationResponseMapper;
 import com.reviewflow.shared.exception.ApiResponse;
 import com.reviewflow.evaluation.dto.response.EvaluationResponse;
 import com.reviewflow.submission.dto.response.SubmissionResponse;
@@ -20,7 +19,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -151,14 +149,6 @@ public class StudentController {
 
   private EvaluationResponse toEvalResponse(Evaluation ev) {
     List<RubricScore> scores = evaluationService.getRubricScoresForEvaluation(ev.getId());
-    BigDecimal maxPossible =
-        scores.stream()
-            .map(
-                s ->
-                    s.getCriterion() != null && s.getCriterion().getMaxScore() != null
-                        ? BigDecimal.valueOf(s.getCriterion().getMaxScore())
-                        : BigDecimal.ZERO)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
-    return getEvaluationResponse(ev, scores, maxPossible, hashidService);
+    return EvaluationResponseMapper.toResponse(ev, scores, hashidService);
   }
 }

--- a/src/main/java/com/reviewflow/shared/api/ValidationFieldError.java
+++ b/src/main/java/com/reviewflow/shared/api/ValidationFieldError.java
@@ -1,4 +1,0 @@
-package com.reviewflow.shared.api;
-
-public record ValidationFieldError(
-    String field, String message, String rejectedValue) {}


### PR DESCRIPTION
Delete unused shared.api.ValidationFieldError in favor of shared.dto, wire EvaluationResponseMapper as the single mapping path, and align agent doc package references with the codebase.