### PR TITLE
fix: harden async executors with rejection handling and observability

### DIFF
--- a/src/main/java/com/reviewflow/course/service/CourseService.java
+++ b/src/main/java/com/reviewflow/course/service/CourseService.java
@@ -327,4 +327,12 @@ public class CourseService {
   public int getAssignmentCount(Long courseId) {
     return assignmentRepository.findByCourseId(courseId).size();
   }
+
+  public List<Long> findEnrolledUserIdsByCourseId(Long courseId) {
+    return courseEnrollmentRepository.findUserIdsByCourseId(courseId);
+  }
+
+  public List<CourseEnrollment> findEnrollmentsWithUserByCourseId(Long courseId) {
+    return courseEnrollmentRepository.findWithUserByCourseId(courseId);
+  }
 }

--- a/src/main/java/com/reviewflow/evaluation/listener/PdfGenerationListener.java
+++ b/src/main/java/com/reviewflow/evaluation/listener/PdfGenerationListener.java
@@ -2,7 +2,6 @@ package com.reviewflow.evaluation.listener;
 
 import com.reviewflow.evaluation.event.EvaluationPublishedEvent;
 import com.reviewflow.evaluation.event.PdfReadyEvent;
-import com.reviewflow.evaluation.repository.EvaluationRepository;
 import com.reviewflow.evaluation.dto.EvaluationPdfContext;
 import com.reviewflow.evaluation.service.EvaluationService;
 import com.reviewflow.evaluation.service.PdfGenerationService;
@@ -11,6 +10,7 @@ import com.reviewflow.shared.domain.Evaluation;
 import com.reviewflow.shared.domain.RubricScore;
 import com.reviewflow.shared.domain.SubmissionType;
 import com.reviewflow.grading.repository.RubricScoreRepository;
+import com.reviewflow.evaluation.repository.EvaluationRepository;
 import com.reviewflow.shared.util.HashidService;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +29,7 @@ public class PdfGenerationListener {
   private final EvaluationRepository evaluationRepository;
   private final RubricScoreRepository rubricScoreRepository;
   private final PdfGenerationService pdfGenerationService;
+  private final EvaluationService evaluationService;
   private final HashidService hashidService;
   private final ApplicationEventPublisher eventPublisher;
   private final ReviewFlowMetrics metrics;
@@ -41,14 +42,23 @@ public class PdfGenerationListener {
       Evaluation evaluation =
           evaluationRepository.findByIdWithPdfRelations(event.evaluationId()).orElse(null);
       if (evaluation == null) {
+        log.warn(
+            "PDF generation skipped — evaluation not found id={}", event.evaluationId());
         return;
       }
+
+      if (evaluation.getPdfPath() != null) {
+        log.debug(
+            "PDF generation skipped — pdfPath already set evaluationId={}",
+            event.evaluationId());
+        return;
+      }
+
       List<RubricScore> scores =
           rubricScoreRepository.findByEvaluationIdWithCriterion(event.evaluationId());
       EvaluationPdfContext context = EvaluationService.toPdfContext(evaluation, scores);
       String pdfPath = pdfGenerationService.generateEvaluationPdf(context);
-      evaluation.setPdfPath(pdfPath);
-      evaluationRepository.save(evaluation);
+      evaluationService.updatePdfPath(event.evaluationId(), pdfPath);
 
       List<Long> recipients = new ArrayList<>(event.recipientUserIds());
       if (event.submissionType() == SubmissionType.INDIVIDUAL && event.studentId() != null) {
@@ -62,7 +72,11 @@ public class PdfGenerationListener {
               event.assignmentTitle()));
       log.info("PDF generated for evaluation {}", hashedEvalId);
     } catch (Exception e) {
-      log.error("PDF generation failed for evaluation {}: {}", hashedEvalId, e.getMessage());
+      log.error(
+          "PDF generation failed evaluationId={}: {}",
+          hashedEvalId,
+          e.getMessage(),
+          e);
       metrics.recordPdfGenerationFailed();
     }
   }

--- a/src/main/java/com/reviewflow/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/reviewflow/evaluation/service/EvaluationService.java
@@ -535,4 +535,14 @@ public class EvaluationService {
         .filename("evaluation.pdf")
         .build();
   }
+
+  @Transactional
+  public void updatePdfPath(Long evaluationId, String pdfPath) {
+    Evaluation evaluation =
+        evaluationRepository
+            .findById(evaluationId)
+            .orElseThrow(() -> new ResourceNotFoundException("Evaluation", evaluationId));
+    evaluation.setPdfPath(pdfPath);
+    evaluationRepository.save(evaluation);
+  }
 }

--- a/src/main/java/com/reviewflow/grading/event/GradeAggregateUpdateListener.java
+++ b/src/main/java/com/reviewflow/grading/event/GradeAggregateUpdateListener.java
@@ -4,7 +4,10 @@ import com.reviewflow.course.repository.CourseEnrollmentRepository;
 import com.reviewflow.grading.dto.response.GradeOverviewDto;
 import com.reviewflow.grading.service.GradeAggregateService;
 import com.reviewflow.grading.service.GradeCalculationService;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -19,21 +22,35 @@ public class GradeAggregateUpdateListener {
   private final GradeAggregateService gradeAggregateService;
   private final GradeCalculationService gradeCalculationService;
   private final CourseEnrollmentRepository courseEnrollmentRepository;
+  private final ReviewFlowMetrics metrics;
+
+  private final Set<String> pendingRecomputes = ConcurrentHashMap.newKeySet();
 
   @Async("gradeAggregateExecutor")
   @EventListener
   public void handleGradePublished(GradePublishedEvent event) {
+    String key = event.courseId() + ":" + event.studentId();
+
+    if (!pendingRecomputes.add(key)) {
+      log.debug("Grade aggregate recompute already queued for key={}", key);
+      return;
+    }
+
     try {
       gradeAggregateService.evictStudent(event.courseId(), event.studentId());
       GradeOverviewDto fresh =
           gradeCalculationService.calculateOverviewFromDb(event.courseId(), event.studentId());
       gradeAggregateService.storeInRedis(event.courseId(), event.studentId(), fresh);
     } catch (Exception e) {
-      log.warn(
-          "Grade aggregate update failed for student {} in course {}: {}",
-          event.studentId(),
+      metrics.recordGradeAggregateFailed();
+      log.error(
+          "Grade aggregate update failed courseId={} studentId={}: {}",
           event.courseId(),
-          e.getMessage());
+          event.studentId(),
+          e.getMessage(),
+          e);
+    } finally {
+      pendingRecomputes.remove(key);
     }
   }
 
@@ -52,15 +69,19 @@ public class GradeAggregateUpdateListener {
               gradeCalculationService.calculateOverviewFromDb(event.courseId(), studentId);
           gradeAggregateService.storeInRedis(event.courseId(), studentId, fresh);
         } catch (Exception ex) {
-          log.warn(
+          metrics.recordGradeAggregateFailed();
+          log.error(
               "Batch recompute failed for student {} in course {}: {}",
               studentId,
               event.courseId(),
-              ex.getMessage());
+              ex.getMessage(),
+              ex);
         }
       }
     } catch (Exception e) {
-      log.warn("Grade structure update failed for course {}: {}", event.courseId(), e.getMessage());
+      metrics.recordGradeAggregateFailed();
+      log.error(
+          "Grade structure update failed for course {}: {}", event.courseId(), e.getMessage(), e);
     }
   }
 }

--- a/src/main/java/com/reviewflow/grading/service/CsvImportService.java
+++ b/src/main/java/com/reviewflow/grading/service/CsvImportService.java
@@ -15,6 +15,8 @@ import com.reviewflow.infrastructure.config.ValidationConfig;
 import com.reviewflow.infrastructure.jobs.AsyncJobService;
 import com.reviewflow.infrastructure.jobs.JobProgressEvent;
 import com.reviewflow.infrastructure.jobs.SseEmitterRegistry;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
+import com.reviewflow.shared.exception.ServiceUnavailableException;
 import com.reviewflow.infrastructure.storage.FileSecurityValidator;
 import com.reviewflow.infrastructure.storage.S3Service;
 import com.reviewflow.shared.domain.Assignment;
@@ -38,7 +40,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -67,6 +71,7 @@ public class CsvImportService {
   private final ObjectMapper objectMapper;
   private final Executor csvWorkerExecutor;
   private final Executor uploadExecutor;
+  private final ReviewFlowMetrics metrics;
 
   public CsvImportService(
       AssignmentRepository assignmentRepository,
@@ -83,7 +88,8 @@ public class CsvImportService {
       HashidService hashidService,
       ObjectMapper objectMapper,
       @Qualifier("csvWorkerExecutor") Executor csvWorkerExecutor,
-      @Qualifier("uploadExecutor") Executor uploadExecutor) {
+      @Qualifier("uploadExecutor") Executor uploadExecutor,
+      ReviewFlowMetrics metrics) {
     this.assignmentRepository = assignmentRepository;
     this.userRepository = userRepository;
     this.teamRepository = teamRepository;
@@ -99,6 +105,7 @@ public class CsvImportService {
     this.objectMapper = objectMapper;
     this.csvWorkerExecutor = csvWorkerExecutor;
     this.uploadExecutor = uploadExecutor;
+    this.metrics = metrics;
   }
 
   public ImportJobStartResponse startImport(Long assignmentId, Long actorId, MultipartFile file) {
@@ -136,8 +143,10 @@ public class CsvImportService {
     }
 
     String sourceKey = "imports/" + jobId + "/source.csv";
+    CompletableFuture<Void> uploadFuture;
     try {
-      CompletableFuture.runAsync(
+      uploadFuture =
+          CompletableFuture.runAsync(
               () -> {
                 try {
                   s3Service.putObject(
@@ -146,14 +155,26 @@ public class CsvImportService {
                   throw new StorageException("Failed to upload source CSV", e);
                 }
               },
-              uploadExecutor)
-          .join();
-    } catch (Exception e) {
+              uploadExecutor);
+    } catch (RejectedExecutionException e) {
+      metrics.recordAsyncRejected("uploadExecutor");
       asyncJobService.releaseImportLock(hashedCourseId);
+      throw new ServiceUnavailableException(
+          "Upload service is temporarily at capacity. Please try again.");
+    }
+    try {
+      uploadFuture.join();
+    } catch (CompletionException e) {
+      asyncJobService.releaseImportLock(hashedCourseId);
+      if (e.getCause() instanceof RejectedExecutionException) {
+        metrics.recordAsyncRejected("uploadExecutor");
+        throw new ServiceUnavailableException(
+            "Upload service is temporarily at capacity. Please try again.");
+      }
       if (e.getCause() instanceof StorageException se) {
         throw se;
       }
-      throw new StorageException("Failed to upload source CSV", e);
+      throw new StorageException("Failed to upload source CSV", e.getCause());
     }
 
     Instant now = Instant.now();
@@ -176,7 +197,22 @@ public class CsvImportService {
             now);
     asyncJobService.saveJob(initial);
 
-    CompletableFuture.runAsync(() -> runValidation(jobId), csvWorkerExecutor);
+    try {
+      CompletableFuture.runAsync(() -> runValidation(jobId), csvWorkerExecutor);
+    } catch (RejectedExecutionException e) {
+      metrics.recordAsyncRejected("csvWorkerExecutor");
+      metrics.recordJobFailed("csv_import");
+      log.warn("csvWorkerExecutor rejected validation for jobId={}: {}", jobId, e.getMessage());
+
+      String errorMessage =
+          "Import service is temporarily at capacity. Please try again.";
+      asyncJobService.failJob(jobId, hashedCourseId, errorMessage);
+      sseEmitterRegistry.pushFailed(jobId, "Import rejected — service at capacity. Please retry.");
+      sseEmitterRegistry.complete(jobId);
+
+      throw new ServiceUnavailableException(
+          "Import service is temporarily at capacity. Please try again shortly.");
+    }
 
     return ImportJobStartResponse.builder().jobId(jobId).status(JobStatus.UPLOADED).build();
   }
@@ -228,12 +264,10 @@ public class CsvImportService {
       }
     } catch (ValidationException e) {
       failJob(jobId, state.courseId(), e.getMessage());
-      sseEmitterRegistry.complete(jobId);
       return;
     } catch (Exception e) {
       log.error("CSV validation failed for job {}: {}", jobId, e.getMessage(), e);
       failJob(jobId, state.courseId(), e.getMessage());
-      sseEmitterRegistry.complete(jobId);
       return;
     }
 
@@ -285,6 +319,17 @@ public class CsvImportService {
                   s.createdAt(),
                   Instant.now()));
       asyncJobService.releaseImportLock(state.courseId());
+      String validationErrorMessage = "Validation failed — download error CSV for details";
+      sseEmitterRegistry.pushFailed(jobId, validationErrorMessage);
+      sseEmitterRegistry.push(
+          jobId,
+          JobProgressEvent.builder()
+              .processed(processedRows)
+              .total(totalDataRows)
+              .percent(totalDataRows > 0 ? (processedRows * 100) / totalDataRows : 0)
+              .status(JobStatus.VALIDATION_FAILED.name())
+              .errorMessage(validationErrorMessage)
+              .build());
       sseEmitterRegistry.complete(jobId);
       return;
     }
@@ -295,7 +340,6 @@ public class CsvImportService {
       s3Service.putObject(validatedKey, json, "application/json");
     } catch (IOException e) {
       failJob(jobId, state.courseId(), "Failed to store validated rows");
-      sseEmitterRegistry.complete(jobId);
       return;
     }
 
@@ -331,51 +375,19 @@ public class CsvImportService {
       csvImportCommitService.commitJob(jobId);
     } catch (Exception e) {
       log.error("CSV commit failed for job {}: {}", jobId, e.getMessage(), e);
-      asyncJobService.updateJob(
-          jobId,
-          s ->
-              new JobState(
-                  s.jobId(),
-                  JobStatus.FAILED,
-                  s.assignmentId(),
-                  s.instructorId(),
-                  s.courseId(),
-                  s.totalRows(),
-                  s.validRows(),
-                  s.invalidRows(),
-                  s.processedRows(),
-                  s.sourceS3Key(),
-                  s.validatedRowsS3Key(),
-                  s.errorCsvS3Key(),
-                  e.getMessage(),
-                  s.createdAt(),
-                  Instant.now()));
+      String errorMessage = e.getMessage() != null ? e.getMessage() : "Commit failed";
+      asyncJobService.failJob(jobId, courseId, errorMessage);
+      sseEmitterRegistry.pushFailed(jobId, errorMessage);
+      sseEmitterRegistry.complete(jobId);
     } finally {
       asyncJobService.releaseImportLock(courseId);
     }
   }
 
   private void failJob(String jobId, String hashedCourseId, String message) {
-    asyncJobService.updateJob(
-        jobId,
-        s ->
-            new JobState(
-                s.jobId(),
-                JobStatus.FAILED,
-                s.assignmentId(),
-                s.instructorId(),
-                s.courseId(),
-                s.totalRows(),
-                s.validRows(),
-                s.invalidRows(),
-                s.processedRows(),
-                s.sourceS3Key(),
-                s.validatedRowsS3Key(),
-                s.errorCsvS3Key(),
-                message,
-                s.createdAt(),
-                Instant.now()));
-    asyncJobService.releaseImportLock(hashedCourseId);
+    asyncJobService.failJob(jobId, hashedCourseId, message);
+    sseEmitterRegistry.pushFailed(jobId, message);
+    sseEmitterRegistry.complete(jobId);
   }
 
   private void validateDataRow(

--- a/src/main/java/com/reviewflow/grading/service/ImportJobService.java
+++ b/src/main/java/com/reviewflow/grading/service/ImportJobService.java
@@ -9,17 +9,22 @@ import com.reviewflow.grading.job.JobState;
 import com.reviewflow.grading.job.JobStatus;
 import com.reviewflow.infrastructure.jobs.AsyncJobService;
 import com.reviewflow.infrastructure.jobs.SseEmitterRegistry;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
 import com.reviewflow.infrastructure.storage.S3Service;
+import com.reviewflow.shared.exception.ServiceUnavailableException;
 import com.reviewflow.shared.domain.UserRole;
 import com.reviewflow.shared.exception.AccessDeniedException;
 import com.reviewflow.shared.util.HashidService;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
+@Slf4j
 public class ImportJobService {
 
   private final AsyncJobService asyncJobService;
@@ -28,6 +33,7 @@ public class ImportJobService {
   private final S3Service s3Service;
   private final HashidService hashidService;
   private final Executor csvWorkerExecutor;
+  private final ReviewFlowMetrics metrics;
 
   public ImportJobService(
       AsyncJobService asyncJobService,
@@ -35,13 +41,15 @@ public class ImportJobService {
       SseEmitterRegistry sseEmitterRegistry,
       S3Service s3Service,
       HashidService hashidService,
-      @Qualifier("csvWorkerExecutor") Executor csvWorkerExecutor) {
+      @Qualifier("csvWorkerExecutor") Executor csvWorkerExecutor,
+      ReviewFlowMetrics metrics) {
     this.asyncJobService = asyncJobService;
     this.csvImportService = csvImportService;
     this.sseEmitterRegistry = sseEmitterRegistry;
     this.s3Service = s3Service;
     this.hashidService = hashidService;
     this.csvWorkerExecutor = csvWorkerExecutor;
+    this.metrics = metrics;
   }
 
   public JobStatusDto getStatus(String jobId, Long actorId, UserRole actorRole) {
@@ -73,7 +81,16 @@ public class ImportJobService {
           "Commit is only allowed when status is VALIDATION_PASSED");
     }
     asyncJobService.updateStatus(jobId, JobStatus.COMMITTING);
-    CompletableFuture.runAsync(() -> csvImportService.runCommit(jobId), csvWorkerExecutor);
+    try {
+      CompletableFuture.runAsync(() -> csvImportService.runCommit(jobId), csvWorkerExecutor);
+    } catch (RejectedExecutionException e) {
+      metrics.recordAsyncRejected("csvWorkerExecutor");
+      log.warn("csvWorkerExecutor rejected commit for jobId={}", jobId);
+      asyncJobService.updateStatus(jobId, JobStatus.VALIDATION_PASSED);
+      asyncJobService.updateJobError(jobId, "Commit temporarily rejected — please retry.");
+      throw new ServiceUnavailableException(
+          "Commit service is temporarily at capacity. Please try again.");
+    }
     return JobStatusDto.builder().jobId(jobId).status(JobStatus.COMMITTING).build();
   }
 

--- a/src/main/java/com/reviewflow/infrastructure/email/EmailEventListener.java
+++ b/src/main/java/com/reviewflow/infrastructure/email/EmailEventListener.java
@@ -19,6 +19,8 @@ import com.reviewflow.infrastructure.email.event.WelcomeEmailEvent;
 import com.reviewflow.user.repository.UserRepository;
 import com.reviewflow.infrastructure.email.EmailService;
 import com.reviewflow.infrastructure.email.EmailTemplateService;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
+import org.springframework.mail.MailException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,7 @@ public class EmailEventListener {
   private final EmailService emailService;
   private final EmailTemplateService templateService;
   private final UserRepository userRepository;
+  private final ReviewFlowMetrics metrics;
 
   @Value("${app.base-url:http://localhost:5173}")
   private String appBaseUrl;
@@ -327,13 +330,23 @@ public class EmailEventListener {
           "Email sent: event={}, recipient={}",
           event.getClass().getSimpleName(),
           event.getRecipientEmail());
-    } catch (Exception e) {
-      // Never break request flows due to email processing.
+    } catch (MailException e) {
+      String eventType = event.getClass().getSimpleName();
+      metrics.recordEmailFailed(eventType);
       log.error(
-          "Email handler failed: template={}, recipient={}, error={}",
-          template,
+          "Email delivery failed type={} recipient={}: {}",
+          eventType,
           event.getRecipientEmail(),
-          e.getMessage());
+          e.getMessage(),
+          e);
+    } catch (Exception e) {
+      String eventType = event.getClass().getSimpleName();
+      metrics.recordEmailFailed(eventType);
+      log.error(
+          "Unexpected email handler failure type={}: {}",
+          eventType,
+          e.getMessage(),
+          e);
     }
   }
 

--- a/src/main/java/com/reviewflow/infrastructure/email/EmailService.java
+++ b/src/main/java/com/reviewflow/infrastructure/email/EmailService.java
@@ -5,7 +5,6 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -32,9 +31,8 @@ public class EmailService {
 
       mailSender.send(message);
       log.debug("Email sent to {}: {}", to, subject);
-    } catch (MessagingException | MailException e) {
-      // Email is fire-and-forget; never break core request flow on email failures.
-      log.error("Email send failed to {}: {}", to, e.getMessage());
+    } catch (MessagingException e) {
+      throw new org.springframework.mail.MailSendException("Failed to compose email", e);
     }
   }
 }

--- a/src/main/java/com/reviewflow/infrastructure/jobs/AsyncJobConfig.java
+++ b/src/main/java/com/reviewflow/infrastructure/jobs/AsyncJobConfig.java
@@ -1,14 +1,18 @@
 package com.reviewflow.infrastructure.jobs;
 
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
+@Slf4j
 public class AsyncJobConfig {
 
   @Bean(name = "csvWorkerExecutor")
@@ -27,6 +31,8 @@ public class AsyncJobConfig {
     return buildExecutor(core, max, queue, "file-upload-", new ThreadPoolExecutor.AbortPolicy());
   }
 
+  // pdfExecutor: intentionally small (max 3). PDF generation is CPU-bound
+  // via OpenPDF; larger pool on t3.micro would cause GC pressure under load.
   @Bean(name = "pdfExecutor")
   public Executor pdfExecutor(
       @Value("${async.pdf.core-pool-size:1}") int core,
@@ -39,9 +45,63 @@ public class AsyncJobConfig {
   public Executor gradeAggregateExecutor(
       @Value("${async.grade.core-pool-size:2}") int core,
       @Value("${async.grade.max-pool-size:5}") int max,
-      @Value("${async.grade.queue-capacity:100}") int queue) {
-    return buildExecutor(
-        core, max, queue, "grade-agg-", new ThreadPoolExecutor.DiscardOldestPolicy());
+      @Value("${async.grade.queue-capacity:100}") int queue,
+      ReviewFlowMetrics metrics) {
+
+    ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+    exec.setCorePoolSize(core);
+    exec.setMaxPoolSize(max);
+    exec.setQueueCapacity(queue);
+    exec.setThreadNamePrefix("grade-agg-");
+    exec.setWaitForTasksToCompleteOnShutdown(true);
+    exec.setAwaitTerminationSeconds(30);
+
+    exec.setRejectedExecutionHandler(
+        (runnable, executor) -> {
+          if (!executor.getQueue().isEmpty()) {
+            executor.getQueue().poll();
+          }
+          try {
+            executor.execute(runnable);
+          } catch (RejectedExecutionException e) {
+            log.warn(
+                "gradeAggregateExecutor: task dropped after discard-oldest. Queue depth: {}",
+                executor.getQueue().size());
+          }
+          metrics.recordAsyncRejected("gradeAggregateExecutor");
+        });
+
+    exec.initialize();
+    return exec;
+  }
+
+  @Bean(name = "scanExecutor")
+  public Executor scanExecutor(
+      @Value("${async.scan.core-pool-size:1}") int core,
+      @Value("${async.scan.max-pool-size:2}") int max,
+      @Value("${async.scan.queue-capacity:10}") int queue,
+      ReviewFlowMetrics metrics) {
+
+    ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
+    exec.setCorePoolSize(core);
+    exec.setMaxPoolSize(max);
+    exec.setQueueCapacity(queue);
+    exec.setThreadNamePrefix("clamav-scan-");
+    exec.setWaitForTasksToCompleteOnShutdown(true);
+    exec.setAwaitTerminationSeconds(60);
+
+    exec.setRejectedExecutionHandler(
+        (runnable, executor) -> {
+          metrics.recordAsyncRejected("scanExecutor");
+          metrics.recordScanRejected();
+          log.warn(
+              "scanExecutor queue full — ClamAV scan rejected. Queue depth: {}",
+              executor.getQueue().size());
+          throw new RejectedExecutionException("ClamAV scan queue full");
+        });
+
+    exec.initialize();
+    return exec;
   }
 
   private static ThreadPoolTaskExecutor buildExecutor(

--- a/src/main/java/com/reviewflow/infrastructure/jobs/AsyncJobService.java
+++ b/src/main/java/com/reviewflow/infrastructure/jobs/AsyncJobService.java
@@ -99,6 +99,51 @@ public class AsyncJobService {
     redisTemplate.delete(IMPORT_LOCK_PREFIX + courseId);
   }
 
+  public void failJob(String jobId, String hashedCourseId, String reason) {
+    updateJob(
+        jobId,
+        state ->
+            new JobState(
+                state.jobId(),
+                JobStatus.FAILED,
+                state.assignmentId(),
+                state.instructorId(),
+                state.courseId(),
+                state.totalRows(),
+                state.validRows(),
+                state.invalidRows(),
+                state.processedRows(),
+                state.sourceS3Key(),
+                state.validatedRowsS3Key(),
+                state.errorCsvS3Key(),
+                reason,
+                state.createdAt(),
+                Instant.now()));
+    releaseImportLock(hashedCourseId);
+  }
+
+  public void updateJobError(String jobId, String reason) {
+    updateJob(
+        jobId,
+        state ->
+            new JobState(
+                state.jobId(),
+                state.status(),
+                state.assignmentId(),
+                state.instructorId(),
+                state.courseId(),
+                state.totalRows(),
+                state.validRows(),
+                state.invalidRows(),
+                state.processedRows(),
+                state.sourceS3Key(),
+                state.validatedRowsS3Key(),
+                state.errorCsvS3Key(),
+                reason,
+                state.createdAt(),
+                Instant.now()));
+  }
+
   private static JobState withStatus(JobState state, JobStatus status, Instant updatedAt) {
     return new JobState(
         state.jobId(),

--- a/src/main/java/com/reviewflow/infrastructure/jobs/JobProgressEvent.java
+++ b/src/main/java/com/reviewflow/infrastructure/jobs/JobProgressEvent.java
@@ -9,4 +9,6 @@ public class JobProgressEvent {
   int processed;
   int total;
   int percent;
+  String status;
+  String errorMessage;
 }

--- a/src/main/java/com/reviewflow/infrastructure/jobs/SseEmitterRegistry.java
+++ b/src/main/java/com/reviewflow/infrastructure/jobs/SseEmitterRegistry.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -39,6 +40,22 @@ public class SseEmitterRegistry {
           SseEmitter.event().name("progress").data(objectMapper.writeValueAsString(event)));
     } catch (IOException e) {
       log.debug("SSE push failed for job {}: {}", jobId, e.getMessage());
+      emitters.remove(jobId);
+    }
+  }
+
+  public void pushFailed(String jobId, String errorMessage) {
+    SseEmitter emitter = emitters.get(jobId);
+    if (emitter == null) {
+      return;
+    }
+    try {
+      Map<String, String> payload = new HashMap<>();
+      payload.put("status", "FAILED");
+      payload.put("errorMessage", errorMessage);
+      emitter.send(
+          SseEmitter.event().name("failed").data(objectMapper.writeValueAsString(payload)));
+    } catch (IOException e) {
       emitters.remove(jobId);
     }
   }

--- a/src/main/java/com/reviewflow/infrastructure/monitoring/ReviewFlowMetrics.java
+++ b/src/main/java/com/reviewflow/infrastructure/monitoring/ReviewFlowMetrics.java
@@ -298,7 +298,7 @@ public class ReviewFlowMetrics {
   }
 
   public void recordEmailFailed(String eventType) {
-    emailFailedCounter.increment();
+    meterRegistry.counter("reviewflow.email.failed", "type", eventType).increment();
   }
 
   // ──── NOTIFICATIONS ───────────────────────────────────────────
@@ -359,5 +359,21 @@ public class ReviewFlowMetrics {
 
   public void recordRateLimitCheckFailed(String strategy) {
     meterRegistry.counter("reviewflow.ratelimit.check.failed", "strategy", strategy).increment();
+  }
+
+  public void recordAsyncRejected(String executorName) {
+    meterRegistry.counter("reviewflow.async.rejected", "executor", executorName).increment();
+  }
+
+  public void recordGradeAggregateFailed() {
+    meterRegistry.counter("reviewflow.grade.aggregate.failed").increment();
+  }
+
+  public void recordJobFailed(String jobType) {
+    meterRegistry.counter("reviewflow.job.failed", "jobType", jobType).increment();
+  }
+
+  public void recordScanRejected() {
+    meterRegistry.counter("reviewflow.clamav.scan.rejected").increment();
   }
 }

--- a/src/main/java/com/reviewflow/infrastructure/storage/ClamAvScanService.java
+++ b/src/main/java/com/reviewflow/infrastructure/storage/ClamAvScanService.java
@@ -47,7 +47,7 @@ public class ClamAvScanService {
    * Asynchronously scan a file for malware. Returns immediately with a CompletableFuture that
    * completes when scan finishes. Does not block the calling thread.
    */
-  @Async
+  @Async("scanExecutor")
   public CompletableFuture<ClamAvScanResult> scanAsync(Path filePath) {
     if (!enabled) {
       return CompletableFuture.completedFuture(ClamAvScanResult.DISABLED);
@@ -86,6 +86,10 @@ public class ClamAvScanService {
       log.warn("ClamAV scan timeout for file={}", filePath.getFileName());
       securityMetrics.recordClamavError();
       throw new RuntimeException("ClamAV scan timeout");
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      log.warn("ClamAV scan rejected for file={}: queue full", filePath.getFileName());
+      securityMetrics.recordClamavError();
+      throw new RuntimeException("ClamAV scan queue full", e);
     } catch (Exception e) {
       log.error("ClamAV scan failed for file={}: {}", filePath.getFileName(), e.getMessage());
       securityMetrics.recordClamavError();

--- a/src/main/java/com/reviewflow/messaging/service/MessagingService.java
+++ b/src/main/java/com/reviewflow/messaging/service/MessagingService.java
@@ -50,7 +50,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import com.reviewflow.shared.exception.ServiceUnavailableException;
+import org.slf4j.MDC;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -732,18 +736,37 @@ public class MessagingService {
   }
 
   private void uploadBytesToS3(String key, byte[] bytes, String contentType) {
+    Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+    CompletableFuture<Void> uploadFuture;
     try {
-      CompletableFuture.runAsync(
-              () ->
-                  s3Service.putObject(
-                      key, new ByteArrayInputStream(bytes), bytes.length, contentType),
-              uploadExecutor)
-          .get(uploadTimeoutSeconds, TimeUnit.SECONDS);
+      uploadFuture =
+          CompletableFuture.runAsync(
+              () -> {
+                if (mdcContext != null) {
+                  MDC.setContextMap(mdcContext);
+                }
+                s3Service.putObject(
+                    key, new ByteArrayInputStream(bytes), bytes.length, contentType);
+              },
+              uploadExecutor);
+    } catch (RejectedExecutionException e) {
+      reviewFlowMetrics.recordAsyncRejected("uploadExecutor");
+      log.warn("uploadExecutor queue full — message attachment upload rejected for key={}", key);
+      throw new ServiceUnavailableException(
+          "Upload service is temporarily at capacity. Please try again shortly.");
+    }
+    try {
+      uploadFuture.get(uploadTimeoutSeconds, TimeUnit.SECONDS);
     } catch (TimeoutException e) {
       s3Service.deleteObjectSilently(key);
       throw new FileUploadTimeoutException(uploadTimeoutSeconds);
     } catch (ExecutionException e) {
       Throwable cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RejectedExecutionException) {
+        reviewFlowMetrics.recordAsyncRejected("uploadExecutor");
+        throw new ServiceUnavailableException(
+            "Upload service is temporarily at capacity. Please try again shortly.");
+      }
       if (cause instanceof RuntimeException re) {
         throw re;
       }

--- a/src/main/java/com/reviewflow/notification/event/NotificationEventListener.java
+++ b/src/main/java/com/reviewflow/notification/event/NotificationEventListener.java
@@ -5,7 +5,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.List;
 
-import org.springframework.cache.CacheManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -40,11 +39,9 @@ import com.reviewflow.infrastructure.email.event.SubmissionReceivedEmailEvent;
 import com.reviewflow.infrastructure.email.event.TeamInviteReceivedEmailEvent;
 import com.reviewflow.infrastructure.email.event.TeamUnlockedEmailEvent;
 import com.reviewflow.notification.dto.response.NotificationDto;
-import com.reviewflow.notification.repository.NotificationRepository;
 import com.reviewflow.notification.service.NotificationService;
-import com.reviewflow.course.repository.CourseEnrollmentRepository;
-import com.reviewflow.user.repository.UserRepository;
-import com.reviewflow.shared.constant.CacheNames;
+import com.reviewflow.course.service.CourseService;
+import com.reviewflow.user.service.UserService;
 import com.reviewflow.shared.domain.CourseEnrollment;
 import com.reviewflow.shared.domain.Notification;
 import com.reviewflow.shared.domain.NotificationType;
@@ -63,12 +60,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationEventListener {
 
-  private final NotificationRepository notificationRepository;
   private final SimpMessagingTemplate messagingTemplate;
-  private final CacheManager cacheManager;
   private final HashidService hashidService;
-  private final UserRepository userRepository;
-  private final CourseEnrollmentRepository courseEnrollmentRepository;
+  private final UserService userService;
+  private final CourseService courseService;
   private final NotificationService notificationService;
   private final ApplicationEventPublisher eventPublisher;
 
@@ -79,14 +74,14 @@ public class NotificationEventListener {
     List<Long> recipientUserIds;
 
     if ("COURSE".equals(event.getTarget())) {
-      recipientUserIds = courseEnrollmentRepository.findUserIdsByCourseId(event.getCourseId());
+      recipientUserIds = courseService.findEnrolledUserIdsByCourseId(event.getCourseId());
     } else {
       if ("ALL_STUDENTS".equals(event.getRecipientType())) {
-        recipientUserIds = userRepository.findAllIdsByRole(UserRole.STUDENT);
+        recipientUserIds = userService.findAllUserIdsByRole(UserRole.STUDENT);
       } else if ("ALL_INSTRUCTORS".equals(event.getRecipientType())) {
-        recipientUserIds = userRepository.findAllIdsByRole(UserRole.INSTRUCTOR);
+        recipientUserIds = userService.findAllUserIdsByRole(UserRole.INSTRUCTOR);
       } else {
-        recipientUserIds = userRepository.findAllIds();
+        recipientUserIds = userService.findAllUserIds();
       }
     }
 
@@ -100,8 +95,8 @@ public class NotificationEventListener {
           "/announcements/{id}",
           event.getAnnouncementId());
 
-      userRepository
-          .findById(recipientUserId)
+      userService
+          .findUserById(recipientUserId)
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -123,7 +118,7 @@ public class NotificationEventListener {
     String title = "New discussion";
     String message = event.title();
     String discussionHashId = hashidService.encode(event.discussionId());
-    for (CourseEnrollment e : courseEnrollmentRepository.findWithUserByCourseId(event.courseId())) {
+    for (CourseEnrollment e : courseService.findEnrollmentsWithUserByCourseId(event.courseId())) {
       if (e.getUser().getRole() != UserRole.STUDENT) {
         continue;
       }
@@ -164,8 +159,8 @@ public class NotificationEventListener {
         "/discussions/{id}",
         event.discussionId());
     if (event.originalAuthorRole() == UserRole.STUDENT && isStaffRole(event.replierRole())) {
-      userRepository
-          .findById(event.originalAuthorId())
+      userService
+          .findUserById(event.originalAuthorId())
           .ifPresent(
               original ->
                   eventPublisher.publishEvent(
@@ -232,8 +227,8 @@ public class NotificationEventListener {
         "/teams/{id}",
         event.teamId());
 
-    userRepository
-        .findById(event.inviteeUserId())
+    userService
+        .findUserById(event.inviteeUserId())
         .ifPresent(
             user ->
                 eventPublisher.publishEvent(
@@ -264,8 +259,8 @@ public class NotificationEventListener {
         "/assignments/" + event.assignmentId() + "/submissions");
 
     for (Long recipientUserId : event.recipientUserIds()) {
-      userRepository
-          .findById(recipientUserId)
+      userService
+          .findUserById(recipientUserId)
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -298,8 +293,8 @@ public class NotificationEventListener {
           message,
           "/assignments/" + event.assignmentId() + "/feedback");
 
-      userRepository
-          .findById(event.studentId())
+      userService
+          .findUserById(event.studentId())
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -321,8 +316,8 @@ public class NotificationEventListener {
         "/assignments/" + event.assignmentId() + "/feedback");
 
     for (Long recipientUserId : event.recipientUserIds()) {
-      userRepository
-          .findById(recipientUserId)
+      userService
+          .findUserById(recipientUserId)
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -372,31 +367,36 @@ public class NotificationEventListener {
             ? NotificationType.DEADLINE_WARNING_24H
             : NotificationType.DEADLINE_WARNING_48H;
 
-    saveAndPushMany(
-        event.recipientUserIds(),
-        type,
-        "Assignment Due Soon",
+    String title = "Assignment Due Soon";
+    String message =
         event.assignmentTitle()
             + " ("
             + event.courseCode()
             + ") is due in "
             + event.hoursUntilDue()
-            + " hours. You have not submitted yet.",
-        "/assignments/" + event.assignmentId() + "/submit");
+            + " hours. You have not submitted yet.";
+    String actionUrl = "/assignments/" + event.assignmentId() + "/submit";
 
     for (Long recipientUserId : event.recipientUserIds()) {
-      userRepository
-          .findById(recipientUserId)
+      notificationService
+          .tryCreateDedupedDeadlineReminder(
+              recipientUserId, type, event.assignmentId(), title, message, actionUrl)
           .ifPresent(
-              user ->
-                  eventPublisher.publishEvent(
-                      new AssignmentDueSoonEmailEvent(
-                          user.getEmail(),
-                          user.getFullNameOrEmail(),
-                          event.assignmentTitle(),
-                          event.dueAt(),
-                          event.courseCode(),
-                          hashidService.encode(event.assignmentId()))));
+              saved -> {
+                pushNotification(recipientUserId, saved);
+                userService
+                    .findUserById(recipientUserId)
+                    .ifPresent(
+                        user ->
+                            eventPublisher.publishEvent(
+                                new AssignmentDueSoonEmailEvent(
+                                    user.getEmail(),
+                                    user.getFullNameOrEmail(),
+                                    event.assignmentTitle(),
+                                    event.dueAt(),
+                                    event.courseCode(),
+                                    hashidService.encode(event.assignmentId()))));
+              });
     }
   }
 
@@ -413,8 +413,8 @@ public class NotificationEventListener {
           "/extension-requests/{id}",
           event.extensionRequestId());
 
-      userRepository
-          .findById(instructorUserId)
+      userService
+          .findUserById(instructorUserId)
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -447,8 +447,8 @@ public class NotificationEventListener {
         "/extension-requests/{id}");
 
     for (Long recipientUserId : event.recipientUserIds()) {
-      userRepository
-          .findById(recipientUserId)
+      userService
+          .findUserById(recipientUserId)
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -488,31 +488,20 @@ public class NotificationEventListener {
       String message,
       String actionUrl,
       Long targetId) {
-    Notification notification =
-        Notification.builder()
-            .userId(userId)
-            .type(type)
-            .title(title)
-            .message(message)
-            .actionUrl(actionUrl)
-            .targetId(targetId)
-            .build();
+    Notification saved =
+        notificationService.create(userId, type, title, message, actionUrl, targetId);
+    pushNotification(userId, saved);
+  }
 
-    notificationRepository.save(notification);
-
-    var cache = cacheManager.getCache(CacheNames.CACHE_UNREAD_COUNT);
-    if (cache != null) {
-      cache.evict(userId);
-    }
-
+  private void pushNotification(Long userId, Notification notification) {
     try {
       messagingTemplate.convertAndSendToUser(
           userId.toString(),
           "/queue/notifications",
           NotificationDto.from(notification, hashidService));
-      log.debug("Pushed {} to user {}", type, userId);
+      log.debug("Pushed {} to user {}", notification.getType(), userId);
     } catch (Exception e) {
-      log.debug("User {} offline - {} saved to DB only", userId, type);
+      log.debug("User {} offline - {} saved to DB only", userId, notification.getType());
     }
   }
 
@@ -560,8 +549,8 @@ public class NotificationEventListener {
           message,
           "/teams/" + hashidService.encode(event.getTeamId()));
 
-      userRepository
-          .findById(Long.valueOf(member.getId()))
+      userService
+          .findUserById(Long.valueOf(member.getId()))
           .ifPresent(
               user ->
                   eventPublisher.publishEvent(
@@ -584,8 +573,8 @@ public class NotificationEventListener {
             + event.getReason();
     String instructorEmail = event.getInstructorEmail();
 
-    userRepository
-        .findByEmail(instructorEmail)
+    userService
+        .findUserByEmail(instructorEmail)
         .ifPresent(
             instructor ->
                 saveAndPush(
@@ -604,8 +593,8 @@ public class NotificationEventListener {
             + " update the scores. Reason: "
             + event.getReason();
     for (String teamMemberEmail : event.getTeamMemberEmails()) {
-      userRepository
-          .findByEmail(teamMemberEmail)
+      userService
+          .findUserByEmail(teamMemberEmail)
           .ifPresent(
               member -> {
                 saveAndPush(

--- a/src/main/java/com/reviewflow/notification/service/NotificationService.java
+++ b/src/main/java/com/reviewflow/notification/service/NotificationService.java
@@ -32,8 +32,21 @@ public class NotificationService {
   private final HashidService hashidService;
 
   @Transactional
+  @CacheEvict(value = CacheNames.CACHE_UNREAD_COUNT, key = "#userId")
   public Notification create(
       Long userId, NotificationType type, String title, String message, String actionUrl) {
+    return create(userId, type, title, message, actionUrl, null);
+  }
+
+  @Transactional
+  @CacheEvict(value = CacheNames.CACHE_UNREAD_COUNT, key = "#userId")
+  public Notification create(
+      Long userId,
+      NotificationType type,
+      String title,
+      String message,
+      String actionUrl,
+      Long targetId) {
     Notification n =
         Notification.builder()
             .userId(userId)
@@ -41,9 +54,42 @@ public class NotificationService {
             .title(title)
             .message(message)
             .actionUrl(actionUrl)
+            .targetId(targetId)
             .isRead(false)
             .build();
     return notificationRepository.save(n);
+  }
+
+  /**
+   * Idempotent per (user, type, assignment, UTC calendar day) via {@code uk_notification_dedup}.
+   */
+  @Transactional
+  @CacheEvict(value = CacheNames.CACHE_UNREAD_COUNT, key = "#userId")
+  public Optional<Notification> tryCreateDedupedDeadlineReminder(
+      Long userId,
+      NotificationType type,
+      Long assignmentId,
+      String title,
+      String message,
+      String actionUrl) {
+    Notification n =
+        Notification.builder()
+            .userId(userId)
+            .type(type)
+            .title(title)
+            .message(message)
+            .actionUrl(actionUrl)
+            .targetId(assignmentId)
+            .dateBucket(LocalDate.now(ZoneOffset.UTC))
+            .isRead(false)
+            .build();
+    try {
+      Notification saved = notificationRepository.save(n);
+      notificationRepository.flush();
+      return Optional.of(saved);
+    } catch (DataIntegrityViolationException ex) {
+      return Optional.empty();
+    }
   }
 
   /**

--- a/src/main/java/com/reviewflow/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/reviewflow/shared/exception/GlobalExceptionHandler.java
@@ -532,6 +532,22 @@ public class GlobalExceptionHandler {
     return errorResponse(ex.getCode(), ex.getMessage(), HttpStatus.REQUEST_TIMEOUT);
   }
 
+  @ExceptionHandler(ServiceUnavailableException.class)
+  public ResponseEntity<ErrorResponse> handleServiceUnavailable(ServiceUnavailableException ex) {
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .error(
+                ErrorResponse.ErrorDetail.builder()
+                    .code(ex.getCode())
+                    .message(ex.getMessage())
+                    .build())
+            .timestamp(Instant.now())
+            .build();
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        .header("Retry-After", "30")
+        .body(body);
+  }
+
   @ExceptionHandler(BusinessRuleException.class)
   public ResponseEntity<ErrorResponse> handleBusinessRule(BusinessRuleException ex) {
     ErrorResponse body =

--- a/src/main/java/com/reviewflow/submission/service/SubmissionService.java
+++ b/src/main/java/com/reviewflow/submission/service/SubmissionService.java
@@ -9,8 +9,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
+import com.reviewflow.shared.exception.ServiceUnavailableException;
+import org.slf4j.MDC;
 import com.reviewflow.shared.exception.FileUploadTimeoutException;
 import com.reviewflow.shared.exception.StorageException;
 import com.reviewflow.infrastructure.storage.S3Service;
@@ -100,6 +104,7 @@ public class SubmissionService {
   private final AuditService auditService;
   private final HashidService hashidService;
   private final S3Service s3Service;
+  private final ReviewFlowMetrics reviewFlowMetrics;
 
   @Value("${file.validation.submission.max-size-bytes:104857600}")
   private long submissionMaxFileSizeBytes;
@@ -545,10 +550,15 @@ public class SubmissionService {
 
   private String uploadToStorage(
       String relativePath, java.nio.file.Path tempFile, MultipartFile file) {
+    java.util.Map<String, String> mdcContext = MDC.getCopyOfContextMap();
+    CompletableFuture<String> uploadFuture;
     try {
-      CompletableFuture<String> uploadFuture =
+      uploadFuture =
           CompletableFuture.supplyAsync(
               () -> {
+                if (mdcContext != null) {
+                  MDC.setContextMap(mdcContext);
+                }
                 try (InputStream is = java.nio.file.Files.newInputStream(tempFile)) {
                   return storageService.store(
                       relativePath, is, file.getSize(), file.getContentType());
@@ -557,12 +567,25 @@ public class SubmissionService {
                 }
               },
               uploadExecutor);
+    } catch (RejectedExecutionException e) {
+      reviewFlowMetrics.recordAsyncRejected("uploadExecutor");
+      log.warn(
+          "uploadExecutor queue full — submission upload rejected for path={}", relativePath);
+      throw new ServiceUnavailableException(
+          "Upload service is temporarily at capacity. Please try again shortly.");
+    }
+    try {
       return uploadFuture.get(uploadTimeoutSeconds, TimeUnit.SECONDS);
     } catch (TimeoutException e) {
       s3Service.deleteObjectSilently(relativePath);
       throw new FileUploadTimeoutException(uploadTimeoutSeconds);
     } catch (ExecutionException e) {
       Throwable cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RejectedExecutionException) {
+        reviewFlowMetrics.recordAsyncRejected("uploadExecutor");
+        throw new ServiceUnavailableException(
+            "Upload service is temporarily at capacity. Please try again shortly.");
+      }
       if (cause instanceof RuntimeException re) {
         throw re;
       }

--- a/src/main/java/com/reviewflow/user/service/UserService.java
+++ b/src/main/java/com/reviewflow/user/service/UserService.java
@@ -30,7 +30,9 @@ import com.reviewflow.user.exception.AvatarUploadFailedException;
 import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -122,6 +124,22 @@ public class UserService {
 
   public User getUserById(Long id) {
     return userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("User", id));
+  }
+
+  public Optional<User> findUserById(Long id) {
+    return userRepository.findById(id);
+  }
+
+  public Optional<User> findUserByEmail(String email) {
+    return userRepository.findByEmail(email);
+  }
+
+  public List<Long> findAllUserIdsByRole(UserRole role) {
+    return userRepository.findAllIdsByRole(role);
+  }
+
+  public List<Long> findAllUserIds() {
+    return userRepository.findAllIds();
   }
 
   public UserDetailResponse getUserByIdWithCounts(Long id) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -252,6 +252,10 @@ async.grade.core-pool-size=${ASYNC_GRADE_CORE:2}
 async.grade.max-pool-size=${ASYNC_GRADE_MAX:5}
 async.grade.queue-capacity=${ASYNC_GRADE_QUEUE:100}
 
+async.scan.core-pool-size=${ASYNC_SCAN_CORE:1}
+async.scan.max-pool-size=${ASYNC_SCAN_MAX:2}
+async.scan.queue-capacity=${ASYNC_SCAN_QUEUE:10}
+
 async.job.ttl-hours=${JOB_TTL_HOURS:24}
 async.import.lock.ttl-hours=${IMPORT_LOCK_TTL_HOURS:2}
 grade.aggregate.ttl-minutes=${GRADE_AGGREGATE_TTL_MINUTES:5}

--- a/src/test/java/com/reviewflow/grading/service/CsvImportServiceTest.java
+++ b/src/test/java/com/reviewflow/grading/service/CsvImportServiceTest.java
@@ -19,6 +19,7 @@ import com.reviewflow.grading.job.JobStatus;
 import com.reviewflow.grading.repository.InstructorScoreRepository;
 import com.reviewflow.infrastructure.jobs.AsyncJobService;
 import com.reviewflow.infrastructure.jobs.SseEmitterRegistry;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
 import com.reviewflow.infrastructure.config.ValidationConfig;
 import com.reviewflow.infrastructure.storage.FileSecurityValidator;
 import com.reviewflow.infrastructure.storage.S3Service;
@@ -60,6 +61,7 @@ class CsvImportServiceTest {
   @Mock private HashidService hashidService;
   @Mock private Executor csvWorkerExecutor;
   @Mock private Executor uploadExecutor;
+  @Mock private ReviewFlowMetrics metrics;
 
   private CsvImportService csvImportService;
 
@@ -81,7 +83,8 @@ class CsvImportServiceTest {
             hashidService,
             new ObjectMapper(),
             csvWorkerExecutor,
-            uploadExecutor);
+            uploadExecutor,
+            metrics);
 
   }
 

--- a/src/test/java/com/reviewflow/infrastructure/email/EmailEventListenerTest.java
+++ b/src/test/java/com/reviewflow/infrastructure/email/EmailEventListenerTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import com.reviewflow.infrastructure.monitoring.ReviewFlowMetrics;
+import org.junit.jupiter.api.BeforeEach;
 
 import com.reviewflow.infrastructure.email.EmailEventListener;
 import com.reviewflow.infrastructure.email.event.AccountReactivatedEmailEvent;
@@ -32,8 +35,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class EmailEventListenerTest {
 
   @Mock private EmailService emailService;
@@ -42,7 +48,14 @@ class EmailEventListenerTest {
 
   @Mock private UserRepository userRepository;
 
+  @Mock private ReviewFlowMetrics metrics;
+
   @InjectMocks private EmailEventListener listener;
+
+  @BeforeEach
+  void stubEmailSend() {
+    doNothing().when(emailService).send(anyString(), anyString(), anyString(), anyString());
+  }
 
   @Test
   void handleSubmissionReceived_emailDisabled_skipsSend() {

--- a/src/test/java/com/reviewflow/notification/event/NotificationEventListenerTest.java
+++ b/src/test/java/com/reviewflow/notification/event/NotificationEventListenerTest.java
@@ -15,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.doThrow;
@@ -23,8 +24,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
@@ -37,23 +38,24 @@ import com.reviewflow.infrastructure.email.event.AssignmentDueSoonEmailEvent;
 import com.reviewflow.infrastructure.email.event.EvaluationPublishedEmailEvent;
 import com.reviewflow.infrastructure.email.event.SubmissionReceivedEmailEvent;
 import com.reviewflow.infrastructure.email.event.TeamInviteReceivedEmailEvent;
+import com.reviewflow.notification.service.NotificationService;
+import com.reviewflow.user.service.UserService;
+import com.reviewflow.course.service.CourseService;
 import com.reviewflow.shared.domain.User;
-import com.reviewflow.notification.repository.NotificationRepository;
-import com.reviewflow.user.repository.UserRepository;
 import com.reviewflow.shared.domain.Notification;
 import com.reviewflow.shared.domain.NotificationType;
 import com.reviewflow.shared.domain.SubmissionType;
 import com.reviewflow.shared.util.HashidService;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class NotificationEventListenerTest {
 
-  @Mock private NotificationRepository notificationRepository;
+  @Mock private NotificationService notificationService;
   @Mock private SimpMessagingTemplate messagingTemplate;
-  @Mock private CacheManager cacheManager;
-  @Mock private Cache cache;
   @Mock private HashidService hashidService;
-  @Mock private UserRepository userRepository;
+  @Mock private UserService userService;
+  @Mock private CourseService courseService;
   @Mock private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks private NotificationEventListener listener;
@@ -62,40 +64,65 @@ class NotificationEventListenerTest {
     return User.builder().id(id).email(email).firstName(firstName).lastName(lastName).build();
   }
 
-  private void stubNotificationSave() {
+  private void stubNotificationCreate() {
     AtomicLong id = new AtomicLong(1000L);
-    when(notificationRepository.save(any(Notification.class)))
+    when(notificationService.create(
+            anyLong(),
+            any(NotificationType.class),
+            any(),
+            any(),
+            any(),
+            any()))
         .thenAnswer(
             invocation -> {
-              Notification n = invocation.getArgument(0);
-              if (n.getId() == null) {
-                n.setId(id.getAndIncrement());
-              }
+              Notification n =
+                  Notification.builder()
+                      .id(id.getAndIncrement())
+                      .userId(invocation.getArgument(0))
+                      .type(invocation.getArgument(1))
+                      .title(invocation.getArgument(2))
+                      .message(invocation.getArgument(3))
+                      .actionUrl(invocation.getArgument(4))
+                      .targetId(invocation.getArgument(5))
+                      .build();
               return n;
             });
+    when(notificationService.create(
+            anyLong(), any(NotificationType.class), any(), any(), any()))
+        .thenAnswer(
+            invocation ->
+                Notification.builder()
+                    .id(id.getAndIncrement())
+                    .userId(invocation.getArgument(0))
+                    .type(invocation.getArgument(1))
+                    .title(invocation.getArgument(2))
+                    .message(invocation.getArgument(3))
+                    .actionUrl(invocation.getArgument(4))
+                    .build());
   }
 
   @org.junit.jupiter.api.BeforeEach
   void setUp() {
-    when(cacheManager.getCache(any())).thenReturn(null);
     when(hashidService.encode(anyLong())).thenAnswer(invocation -> "H" + invocation.getArgument(0));
-    stubNotificationSave();
+    stubNotificationCreate();
   }
 
   @Test
   void onTeamInvite_persistsNotificationAndPublishesEmail() {
     TeamInviteEvent event = new TeamInviteEvent(10L, 77L, "Team Delta", "Alex", 12L, "Essay 1");
-    when(userRepository.findById(10L))
+    when(userService.findUserById(10L))
         .thenReturn(Optional.of(user(10L, "invitee@test.local", "Ada", "Lovelace")));
 
     listener.onTeamInvite(event);
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository).save(notificationCaptor.capture());
-    Notification notification = notificationCaptor.getValue();
-    assertEquals(NotificationType.TEAM_INVITE, notification.getType());
-    assertEquals(10L, notification.getUserId());
-    assertEquals(77L, notification.getTargetId());
+    verify(notificationService)
+        .create(
+            eq(10L),
+            eq(NotificationType.TEAM_INVITE),
+            eq("Team Invitation"),
+            any(),
+            eq("/teams/{id}"),
+            eq(77L));
 
     ArgumentCaptor<TeamInviteReceivedEmailEvent> emailCaptor =
         ArgumentCaptor.forClass(TeamInviteReceivedEmailEvent.class);
@@ -120,19 +147,21 @@ class NotificationEventListenerTest {
             SubmissionType.INDIVIDUAL,
             501L);
 
-    when(userRepository.findById(20L))
+    when(userService.findUserById(20L))
         .thenReturn(Optional.of(user(20L, "instructor1@test.local", "Prof", "Kim")));
-    when(userRepository.findById(21L))
+    when(userService.findUserById(21L))
         .thenReturn(Optional.of(user(21L, "instructor2@test.local", "Grace", "Hopper")));
 
     listener.onSubmissionUploaded(event);
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository, times(2)).save(notificationCaptor.capture());
-    List<Notification> saved = notificationCaptor.getAllValues();
-    assertEquals(2, saved.size());
-    assertEquals(NotificationType.NEW_SUBMISSION, saved.get(0).getType());
-    assertEquals(NotificationType.NEW_SUBMISSION, saved.get(1).getType());
+    verify(notificationService, times(2))
+        .create(
+            anyLong(),
+            eq(NotificationType.NEW_SUBMISSION),
+            any(),
+            any(),
+            any(),
+            nullable(Long.class));
 
     ArgumentCaptor<SubmissionReceivedEmailEvent> emailCaptor =
         ArgumentCaptor.forClass(SubmissionReceivedEmailEvent.class);
@@ -150,15 +179,19 @@ class NotificationEventListenerTest {
         new EvaluationPublishedEvent(
             List.of(200L, 201L), 200L, 88L, 18L, "Project 2", 92, 100, SubmissionType.INDIVIDUAL);
 
-    when(userRepository.findById(200L))
+    when(userService.findUserById(200L))
         .thenReturn(Optional.of(user(200L, "student@test.local", "Ada", "Lovelace")));
 
     listener.onEvaluationPublished(event);
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository).save(notificationCaptor.capture());
-    assertEquals(200L, notificationCaptor.getValue().getUserId());
-    assertEquals(NotificationType.FEEDBACK_PUBLISHED, notificationCaptor.getValue().getType());
+    verify(notificationService)
+        .create(
+            eq(200L),
+            eq(NotificationType.FEEDBACK_PUBLISHED),
+            any(),
+            any(),
+            any(),
+            nullable(Long.class));
 
     ArgumentCaptor<EvaluationPublishedEmailEvent> emailCaptor =
         ArgumentCaptor.forClass(EvaluationPublishedEmailEvent.class);
@@ -175,14 +208,21 @@ class NotificationEventListenerTest {
         new EvaluationPublishedEvent(
             List.of(300L, 301L), null, 99L, 19L, "Project Team", 75, 100, SubmissionType.TEAM);
 
-    when(userRepository.findById(300L))
+    when(userService.findUserById(300L))
         .thenReturn(Optional.of(user(300L, "team1@test.local", "Alan", "Turing")));
-    when(userRepository.findById(301L))
+    when(userService.findUserById(301L))
         .thenReturn(Optional.of(user(301L, "team2@test.local", "Katherine", "Johnson")));
 
     listener.onEvaluationPublished(event);
 
-    verify(notificationRepository, times(2)).save(any(Notification.class));
+    verify(notificationService, times(2))
+        .create(
+            anyLong(),
+            eq(NotificationType.FEEDBACK_PUBLISHED),
+            any(),
+            any(),
+            any(),
+            nullable(Long.class));
 
     ArgumentCaptor<EvaluationPublishedEmailEvent> emailCaptor =
         ArgumentCaptor.forClass(EvaluationPublishedEmailEvent.class);
@@ -200,17 +240,14 @@ class NotificationEventListenerTest {
 
     listener.onPdfReady(event);
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository, times(2)).save(notificationCaptor.capture());
-    List<Notification> notifications = notificationCaptor.getAllValues();
-    assertEquals(2, notifications.size());
-    for (Notification n : notifications) {
-      assertEquals(NotificationType.FEEDBACK_PUBLISHED, n.getType());
-      assertEquals("Evaluation Report Ready", n.getTitle());
-      assertEquals("/evaluations/H88/pdf", n.getActionUrl());
-    }
-    assertEquals(200L, notifications.get(0).getUserId());
-    assertEquals(201L, notifications.get(1).getUserId());
+    verify(notificationService, times(2))
+        .create(
+            anyLong(),
+            eq(NotificationType.FEEDBACK_PUBLISHED),
+            eq("Evaluation Report Ready"),
+            any(),
+            eq("/evaluations/H88/pdf"),
+            nullable(Long.class));
     verify(eventPublisher, never()).publishEvent(any());
   }
 
@@ -221,15 +258,14 @@ class NotificationEventListenerTest {
 
     listener.onTeamLocked(event);
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository, times(3)).save(notificationCaptor.capture());
-    List<Notification> notifications = notificationCaptor.getAllValues();
-    List<Long> ids = new ArrayList<>();
-    for (Notification n : notifications) {
-      assertEquals(NotificationType.TEAM_LOCKED, n.getType());
-      ids.add(n.getUserId());
-    }
-    assertEquals(List.of(40L, 41L, 42L), ids);
+    verify(notificationService, times(3))
+        .create(
+            anyLong(),
+            eq(NotificationType.TEAM_LOCKED),
+            any(),
+            any(),
+            any(),
+            nullable(Long.class));
   }
 
   @Test
@@ -238,7 +274,16 @@ class NotificationEventListenerTest {
     DeadlineWarningEvent event =
         new DeadlineWarningEvent(List.of(31L), 12L, "Project 2", "CSC101", 24, dueAt);
 
-    when(userRepository.findById(31L))
+    Notification saved =
+        Notification.builder()
+            .id(1L)
+            .userId(31L)
+            .type(NotificationType.DEADLINE_WARNING_24H)
+            .build();
+    when(notificationService.tryCreateDedupedDeadlineReminder(
+            eq(31L), eq(NotificationType.DEADLINE_WARNING_24H), eq(12L), any(), any(), any()))
+        .thenReturn(Optional.of(saved));
+    when(userService.findUserById(31L))
         .thenReturn(Optional.of(user(31L, "student@test.local", "Ada", "Lovelace")));
 
     listener.onDeadlineWarning(event);
@@ -252,9 +297,9 @@ class NotificationEventListenerTest {
     assertEquals(dueAt, published.getDueAt());
     assertEquals("H12", published.getAssignmentHashId());
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository).save(notificationCaptor.capture());
-    assertEquals(NotificationType.DEADLINE_WARNING_24H, notificationCaptor.getValue().getType());
+    verify(notificationService)
+        .tryCreateDedupedDeadlineReminder(
+            eq(31L), eq(NotificationType.DEADLINE_WARNING_24H), eq(12L), any(), any(), any());
   }
 
   @Test
@@ -263,27 +308,41 @@ class NotificationEventListenerTest {
     DeadlineWarningEvent event =
         new DeadlineWarningEvent(List.of(41L), 13L, "Project 3", "CSC201", 48, dueAt);
 
-    when(userRepository.findById(41L))
-        .thenReturn(Optional.of(user(41L, "student2@test.local", "Grace", "Hopper")));
+    Notification saved =
+        Notification.builder()
+            .id(2L)
+            .userId(41L)
+            .type(NotificationType.DEADLINE_WARNING_48H)
+            .build();
+    when(notificationService.tryCreateDedupedDeadlineReminder(
+            eq(41L), eq(NotificationType.DEADLINE_WARNING_48H), eq(13L), any(), any(), any()))
+        .thenReturn(Optional.of(saved));
 
     listener.onDeadlineWarning(event);
 
-    ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
-    verify(notificationRepository).save(notificationCaptor.capture());
-    assertEquals(NotificationType.DEADLINE_WARNING_48H, notificationCaptor.getValue().getType());
+    verify(notificationService)
+        .tryCreateDedupedDeadlineReminder(
+            eq(41L), eq(NotificationType.DEADLINE_WARNING_48H), eq(13L), any(), any(), any());
   }
 
   @Test
   void onTeamInvite_pushFailureStillPersistsAndReturns() {
     TeamInviteEvent event = new TeamInviteEvent(55L, 900L, "Beta", "Maria", 44L, "Capstone");
-    when(userRepository.findById(55L))
+    when(userService.findUserById(55L))
         .thenReturn(Optional.of(user(55L, "beta@test.local", "Beta", "User")));
     doThrow(new RuntimeException("offline"))
         .when(messagingTemplate)
         .convertAndSendToUser(eq("55"), eq("/queue/notifications"), any());
 
     assertDoesNotThrow(() -> listener.onTeamInvite(event));
-    verify(notificationRepository).save(any(Notification.class));
+    verify(notificationService)
+        .create(
+            eq(55L),
+            eq(NotificationType.TEAM_INVITE),
+            any(),
+            any(),
+            any(),
+            eq(900L));
     verify(eventPublisher).publishEvent(any(TeamInviteReceivedEmailEvent.class));
   }
 }


### PR DESCRIPTION
Map pool saturation to 503 responses, release import locks on failure, emit SSE terminal events, and add metrics for rejections, email, and grade aggregates.