### PR TITLE
fix(db): add V35 integrity hardening for optimistic locking and N+1 f…

### DIFF
--- a/src/main/java/com/reviewflow/assignment/controller/AssignmentController.java
+++ b/src/main/java/com/reviewflow/assignment/controller/AssignmentController.java
@@ -470,13 +470,19 @@ public class AssignmentController {
   @PreAuthorize("hasRole('INSTRUCTOR') or hasRole('ADMIN')")
   @GetMapping("/assignments/{id}/submissions")
   public ResponseEntity<ApiResponse<List<SubmissionResponse>>> getSubmissions(
-      @PathVariable String id, @AuthenticationPrincipal ReviewFlowUserDetails user) {
+      @PathVariable String id,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size,
+      @AuthenticationPrincipal ReviewFlowUserDetails user) {
     Long assignmentId = hashidService.decodeOrThrow(id);
-    List<Submission> submissions =
-        assignmentService.getSubmissionsForAssignment(assignmentId, user.getUserId());
+    var submissions =
+        assignmentService.getSubmissionsForAssignment(
+            assignmentId, user.getUserId(), page, size);
     List<SubmissionResponse> data =
-        submissions.stream().map(this::toSubmissionResponse).collect(Collectors.toList());
-    return ResponseEntity.ok(ApiResponse.ok(data));
+        submissions.getContent().stream().map(this::toSubmissionResponse).toList();
+    return ResponseEntity.ok()
+        .headers(com.reviewflow.shared.util.PaginationHeaders.forPage(submissions))
+        .body(ApiResponse.ok(data));
   }
 
   @Operation(

--- a/src/main/java/com/reviewflow/assignment/service/AssignmentService.java
+++ b/src/main/java/com/reviewflow/assignment/service/AssignmentService.java
@@ -42,6 +42,9 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -712,32 +715,24 @@ public class AssignmentService {
     assignmentRepository.delete(a);
   }
 
-  public List<Submission> getSubmissionsForAssignment(Long assignmentId, Long userId) {
+  public Page<Submission> getSubmissionsForAssignment(
+      Long assignmentId, Long userId, int page, int size) {
     Assignment a = getAssignmentById(assignmentId);
     ensureInstructor(a.getCourse().getId(), userId);
-    List<Submission> allSubmissions =
-        submissionRepository.findByAssignmentIdOrderByTeamIdAscVersionNumberDesc(assignmentId);
-
-    // Return only the latest submission per team
-    return allSubmissions.stream()
-        .collect(
-            Collectors.groupingBy(
-                s -> s.getTeam().getId(),
-                Collectors.collectingAndThen(
-                    Collectors.maxBy(Comparator.comparing(Submission::getVersionNumber)),
-                    opt -> opt.orElse(null))))
-        .values()
-        .stream()
-        .filter(s -> s != null)
-        .sorted(Comparator.comparing(s -> s.getTeam().getName()))
-        .collect(Collectors.toList());
+    Pageable pageable = PageRequest.of(page, size);
+    if (a.getSubmissionType() == SubmissionType.TEAM) {
+      return submissionRepository.findLatestTeamSubmissionsByAssignmentId(
+          assignmentId, pageable);
+    }
+    return submissionRepository.findLatestIndividualSubmissionsByAssignmentId(
+        assignmentId, pageable);
   }
 
   public List<GradebookEntryResponse> getGradebookForAssignment(Long assignmentId, Long userId) {
     Assignment a = getAssignmentById(assignmentId);
     ensureInstructor(a.getCourse().getId(), userId);
 
-    List<Team> teams = teamRepository.findByAssignmentId(assignmentId);
+    List<Team> teams = teamRepository.findByAssignmentIdWithMembers(assignmentId);
 
     return teams.stream()
         .map(

--- a/src/main/java/com/reviewflow/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/reviewflow/evaluation/service/EvaluationService.java
@@ -35,6 +35,9 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
@@ -158,12 +161,21 @@ public class EvaluationService {
     // Get assignment ID for criterion validation
     Long assignmentId = evaluation.getSubmission().getAssignment().getId();
 
+    Set<Long> criterionIds =
+        scores.stream()
+            .map(entry -> hashidService.decodeOrThrow(entry.getCriterionId()))
+            .collect(Collectors.toSet());
+
+    Map<Long, RubricCriterion> criteriaById =
+        rubricCriterionRepository.findAllById(criterionIds).stream()
+            .collect(Collectors.toMap(RubricCriterion::getId, criterion -> criterion));
+
     for (UpdateScoresRequest.ScoreEntry entry : scores) {
       Long criterionId = hashidService.decodeOrThrow(entry.getCriterionId());
-      RubricCriterion criterion =
-          rubricCriterionRepository
-              .findById(criterionId)
-              .orElseThrow(() -> new ResourceNotFoundException("RubricCriterion", criterionId));
+      RubricCriterion criterion = criteriaById.get(criterionId);
+      if (criterion == null) {
+        throw new ResourceNotFoundException("RubricCriterion", criterionId);
+      }
 
       // Validate criterion belongs to this assignment
       if (!criterion.getAssignment().getId().equals(assignmentId)) {

--- a/src/main/java/com/reviewflow/grading/repository/InstructorScoreRepository.java
+++ b/src/main/java/com/reviewflow/grading/repository/InstructorScoreRepository.java
@@ -1,11 +1,14 @@
 package com.reviewflow.grading.repository;
 
 import com.reviewflow.shared.domain.InstructorScore;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface InstructorScoreRepository extends JpaRepository<InstructorScore, Long> {
 
@@ -17,6 +20,17 @@ public interface InstructorScoreRepository extends JpaRepository<InstructorScore
 
   List<InstructorScore> findByAssignmentIdInAndStudentIdAndIsPublishedTrue(
       List<Long> assignmentIds, Long studentId);
+
+  @Query(
+      """
+      SELECT s FROM InstructorScore s
+      WHERE s.assignment.id IN :assignmentIds
+          AND s.student.id IN :studentIds
+          AND s.isPublished = true
+      """)
+  List<InstructorScore> findPublishedByAssignmentIdsAndStudentIds(
+      @Param("assignmentIds") List<Long> assignmentIds,
+      @Param("studentIds") Collection<Long> studentIds);
 
   List<InstructorScore> findByAssignmentIdInAndTeamIdAndIsPublishedTrue(
       List<Long> assignmentIds, Long teamId);

--- a/src/main/java/com/reviewflow/grading/service/CsvImportCommitService.java
+++ b/src/main/java/com/reviewflow/grading/service/CsvImportCommitService.java
@@ -6,16 +6,21 @@ import com.reviewflow.assignment.repository.AssignmentRepository;
 import com.reviewflow.grading.job.JobState;
 import com.reviewflow.grading.job.JobStatus;
 import com.reviewflow.grading.job.ValidatedRow;
+import com.reviewflow.grading.repository.InstructorScoreRepository;
 import com.reviewflow.infrastructure.jobs.AsyncJobService;
 import com.reviewflow.infrastructure.storage.S3Service;
 import com.reviewflow.shared.domain.Assignment;
+import com.reviewflow.shared.domain.InstructorScore;
 import com.reviewflow.shared.domain.SubmissionType;
 import com.reviewflow.shared.domain.User;
-import com.reviewflow.shared.exception.ResourceNotFoundException;
 import com.reviewflow.shared.util.HashidService;
 import com.reviewflow.user.repository.UserRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,6 +37,7 @@ public class CsvImportCommitService {
   private final ObjectMapper objectMapper;
   private final AssignmentRepository assignmentRepository;
   private final UserRepository userRepository;
+  private final InstructorScoreRepository instructorScoreRepository;
   private final InstructorScoreService instructorScoreService;
   private final HashidService hashidService;
 
@@ -62,22 +68,32 @@ public class CsvImportCommitService {
     Assignment assignment =
         assignmentRepository
             .findWithDetailsById(assignmentId)
-            .orElseThrow(() -> new ResourceNotFoundException("Assignment", assignmentId));
+            .orElseThrow(
+                () ->
+                    new com.reviewflow.shared.exception.ResourceNotFoundException(
+                        "Assignment", assignmentId));
     boolean teamMode = assignment.getSubmissionType() == SubmissionType.TEAM;
 
-    for (ValidatedRow row : rows) {
-      if (teamMode) {
+    if (teamMode) {
+      for (ValidatedRow row : rows) {
         Long teamId = parseTeamId(row.teamId());
         instructorScoreService.create(
             assignmentId, actorId, null, teamId, row.score(), row.comment());
-      } else {
-        User student =
-            userRepository
-                .findByEmail(row.studentEmail())
-                .orElseThrow(() -> new ResourceNotFoundException("User", row.studentEmail()));
-        instructorScoreService.create(
-            assignmentId, actorId, student.getId(), null, row.score(), row.comment());
       }
+    } else {
+      Set<String> emails =
+          rows.stream().map(ValidatedRow::studentEmail).collect(Collectors.toSet());
+      Map<String, User> usersByEmail =
+          userRepository.findByEmailIn(emails).stream()
+              .collect(Collectors.toMap(User::getEmail, Function.identity()));
+
+      List<InstructorScore> scores =
+          instructorScoreService.buildScoresForCsvImport(
+              assignmentId, actorId, rows, usersByEmail);
+      // saveAll reduces application round trips; IDENTITY keys still emit one INSERT per row.
+      instructorScoreRepository.saveAll(scores);
+      instructorScoreService.afterCsvImportCommitted(
+          assignment.getCourse().getId(), actorId, scores.size());
     }
 
     asyncJobService.updateStatus(jobId, JobStatus.COMPLETED);

--- a/src/main/java/com/reviewflow/grading/service/GradeCalculationService.java
+++ b/src/main/java/com/reviewflow/grading/service/GradeCalculationService.java
@@ -581,13 +581,17 @@ public class GradeCalculationService {
 
     List<CourseEnrollment> enrollments =
         courseEnrollmentRepository.findWithUserByCourseId(courseId);
+    List<Long> studentIds = enrollments.stream().map(e -> e.getUser().getId()).toList();
+    RosterBulkContext bulkContext =
+        studentIds.isEmpty() ? null : loadRosterBulkContext(courseId, studentIds);
+
     List<ClassRosterDto.StudentStandingDto> students = new ArrayList<>();
     List<BigDecimal> standings = new ArrayList<>();
 
     for (CourseEnrollment enrollment : enrollments) {
       Long studentId = enrollment.getUser().getId();
-      GradeOverviewDto overview = calculateOverviewCached(courseId, studentId);
-      BigDecimal standing = overview.getCurrentStanding();
+      BigDecimal standing =
+          bulkContext == null ? null : computeStandingFromContext(bulkContext, studentId);
       if (standing != null) {
         standings.add(standing);
       }
@@ -634,6 +638,159 @@ public class GradeCalculationService {
         .students(students)
         .build();
   }
+
+  private RosterBulkContext loadRosterBulkContext(Long courseId, List<Long> studentIds) {
+    List<AssignmentGroup> groups = assignmentGroupRepository.findDetailedByCourseId(courseId);
+    List<Long> assignmentIds =
+        groups.stream()
+            .flatMap(group -> group.getAssignments().stream())
+            .map(Assignment::getId)
+            .toList();
+
+    Map<Long, Map<Long, Team>> teamByStudentAndAssignment = new HashMap<>();
+    if (!assignmentIds.isEmpty()) {
+      List<Team> teams =
+          teamRepository.findByAssignmentIdsAndMemberUserIds(assignmentIds, studentIds);
+      for (Team team : teams) {
+        Long assignmentId = team.getAssignment().getId();
+        team.getMembers().stream()
+            .filter(member -> studentIds.contains(member.getUser().getId()))
+            .forEach(
+                member ->
+                    teamByStudentAndAssignment
+                        .computeIfAbsent(member.getUser().getId(), ignored -> new HashMap<>())
+                        .put(assignmentId, team));
+      }
+    }
+
+    Map<Long, Map<Long, Submission>> latestIndividualByStudent = new HashMap<>();
+    if (!assignmentIds.isEmpty()) {
+      submissionRepository
+          .findLatestByAssignmentIdsAndStudentIds(assignmentIds, studentIds)
+          .forEach(
+              submission ->
+                  latestIndividualByStudent
+                      .computeIfAbsent(submission.getStudent().getId(), ignored -> new HashMap<>())
+                      .put(submission.getAssignment().getId(), submission));
+    }
+
+    List<Long> teamIds =
+        teamByStudentAndAssignment.values().stream()
+            .flatMap(map -> map.values().stream())
+            .map(Team::getId)
+            .distinct()
+            .toList();
+
+    Map<Long, Map<Long, Submission>> latestTeamByStudent = new HashMap<>();
+    if (!assignmentIds.isEmpty() && !teamIds.isEmpty()) {
+      Map<String, Submission> teamSubmissionByAssignmentAndTeam =
+          submissionRepository.findLatestByAssignmentIdsAndTeamIds(assignmentIds, teamIds).stream()
+              .collect(
+                  Collectors.toMap(
+                      submission ->
+                          submission.getAssignment().getId() + ":" + submission.getTeam().getId(),
+                      submission -> submission,
+                      (a, b) -> a));
+
+      teamByStudentAndAssignment.forEach(
+          (studentId, teamsByAssignment) ->
+              teamsByAssignment.forEach(
+                  (assignmentId, team) -> {
+                    Submission submission =
+                        teamSubmissionByAssignmentAndTeam.get(
+                            assignmentId + ":" + team.getId());
+                    if (submission != null) {
+                      latestTeamByStudent
+                          .computeIfAbsent(studentId, ignored -> new HashMap<>())
+                          .put(assignmentId, submission);
+                    }
+                  }));
+    }
+
+    Set<Long> submissionIds = new HashSet<>();
+    latestIndividualByStudent
+        .values()
+        .forEach(map -> map.values().forEach(submission -> submissionIds.add(submission.getId())));
+    latestTeamByStudent
+        .values()
+        .forEach(map -> map.values().forEach(submission -> submissionIds.add(submission.getId())));
+
+    Map<Long, Evaluation> publishedEvaluationBySubmissionId =
+        submissionIds.isEmpty()
+            ? Map.of()
+            : evaluationRepository.findPublishedFinalBySubmissionIds(new ArrayList<>(submissionIds))
+                .stream()
+                .collect(
+                    Collectors.toMap(
+                        evaluation -> evaluation.getSubmission().getId(), evaluation -> evaluation));
+
+    Map<Long, Map<Long, InstructorScore>> instructorScoreByStudentAndAssignment = new HashMap<>();
+    if (!assignmentIds.isEmpty()) {
+      instructorScoreRepository
+          .findPublishedByAssignmentIdsAndStudentIds(assignmentIds, studentIds)
+          .forEach(
+              score ->
+                  instructorScoreByStudentAndAssignment
+                      .computeIfAbsent(score.getStudent().getId(), ignored -> new HashMap<>())
+                      .put(score.getAssignment().getId(), score));
+    }
+
+    return new RosterBulkContext(
+        groups,
+        latestIndividualByStudent,
+        latestTeamByStudent,
+        publishedEvaluationBySubmissionId,
+        instructorScoreByStudentAndAssignment);
+  }
+
+  private BigDecimal computeStandingFromContext(RosterBulkContext context, Long studentId) {
+    Map<Long, Submission> latestIndividual =
+        context.latestIndividualByStudent().getOrDefault(studentId, Map.of());
+    Map<Long, Submission> latestTeam =
+        context.latestTeamByStudent().getOrDefault(studentId, Map.of());
+    Map<Long, InstructorScore> instructorScores =
+        context.instructorScoreByStudentAndAssignment().getOrDefault(studentId, Map.of());
+
+    List<GroupGradeDto> groupDtos = new ArrayList<>();
+    for (AssignmentGroup group : context.groups()) {
+      groupDtos.add(
+          calculateGroup(
+              group,
+              latestIndividual,
+              latestTeam,
+              context.publishedEvaluationBySubmissionId(),
+              instructorScores));
+    }
+
+    List<GroupGradeDto> completedGroups =
+        groupDtos.stream().filter(group -> group.getGroupScorePercent() != null).toList();
+
+    if (completedGroups.isEmpty()) {
+      return null;
+    }
+
+    BigDecimal completedWeight =
+        completedGroups.stream()
+            .map(group -> group.getWeight() == null ? BigDecimal.ZERO : group.getWeight())
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    if (completedWeight.compareTo(BigDecimal.ZERO) == 0) {
+      return null;
+    }
+
+    BigDecimal weightedSum =
+        completedGroups.stream()
+            .map(group -> group.getWeight().multiply(group.getGroupScorePercent()))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    return weightedSum.divide(completedWeight, 2, RoundingMode.HALF_UP);
+  }
+
+  private record RosterBulkContext(
+      List<AssignmentGroup> groups,
+      Map<Long, Map<Long, Submission>> latestIndividualByStudent,
+      Map<Long, Map<Long, Submission>> latestTeamByStudent,
+      Map<Long, Evaluation> publishedEvaluationBySubmissionId,
+      Map<Long, Map<Long, InstructorScore>> instructorScoreByStudentAndAssignment) {}
 
   private BigDecimal median(List<BigDecimal> values) {
     int size = values.size();

--- a/src/main/java/com/reviewflow/grading/service/GradeExportService.java
+++ b/src/main/java/com/reviewflow/grading/service/GradeExportService.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -86,7 +87,7 @@ public class GradeExportService {
   private final TeamMemberRepository teamMemberRepository;
   private final AuditService auditService;
 
-  @Transactional
+  @Transactional(readOnly = true)
   public ExportResult export(String courseHashId, String assignmentHashId, Long actorUserId) {
     Long courseId = hashidService.decodeOrThrow(courseHashId);
     Long assignmentId = hashidService.decodeOrThrow(assignmentHashId);
@@ -153,7 +154,9 @@ public class GradeExportService {
 
   private List<String[]> buildTeamRows(Assignment assignment, int maxScore) {
     List<Submission> submissions =
-        submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignment.getId());
+        submissionRepository
+            .findLatestTeamSubmissionsByAssignmentId(assignment.getId(), Pageable.unpaged())
+            .getContent();
     Map<Long, Evaluation> evaluationBySubmissionId =
         findPublishedEvaluationsBySubmissionId(submissions);
 
@@ -203,7 +206,9 @@ public class GradeExportService {
 
   private List<String[]> buildIndividualRows(Assignment assignment, int maxScore) {
     List<Submission> submissions =
-        submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignment.getId());
+        submissionRepository
+            .findLatestIndividualSubmissionsByAssignmentId(assignment.getId(), Pageable.unpaged())
+            .getContent();
     Map<Long, Evaluation> evaluationBySubmissionId =
         findPublishedEvaluationsBySubmissionId(submissions);
 

--- a/src/main/java/com/reviewflow/grading/service/InstructorScoreService.java
+++ b/src/main/java/com/reviewflow/grading/service/InstructorScoreService.java
@@ -25,8 +25,11 @@ import com.reviewflow.shared.util.HashidService;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import com.reviewflow.grading.event.GradePublishedEvent;
+import com.reviewflow.grading.job.ValidatedRow;
 import com.reviewflow.grading.event.GradeStructureChangedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -135,6 +138,67 @@ public class InstructorScoreService {
         null);
     gradeCalculationService.evictCourseGradeCaches(assignment.getCourse().getId());
     return toResponse(saved);
+  }
+
+  /** Builds instructor score entities for CSV import without persisting (caller uses saveAll). */
+  public List<InstructorScore> buildScoresForCsvImport(
+      Long assignmentId,
+      Long actorId,
+      List<ValidatedRow> rows,
+      Map<String, User> usersByEmail) {
+    Assignment assignment = getAssignment(assignmentId);
+    validateInstructorGraded(assignment);
+    ensureCanManage(assignment.getCourse().getId(), actorId);
+    User actor = getUser(actorId);
+
+    List<InstructorScore> scores = new ArrayList<>();
+    for (ValidatedRow row : rows) {
+      User student = usersByEmail.get(row.studentEmail());
+      if (student == null) {
+        throw new ResourceNotFoundException("User", row.studentEmail());
+      }
+      validateScore(row.score(), assignment.getMaxScore());
+      if (!courseEnrollmentRepository.existsByCourseIdAndUserId(
+          assignment.getCourse().getId(), student.getId())) {
+        throw new AccessDeniedException("Student is not enrolled in this course");
+      }
+
+      InstructorScore existing =
+          instructorScoreRepository
+              .findByAssignmentIdAndStudentId(assignmentId, student.getId())
+              .orElse(null);
+      if (existing != null && Boolean.TRUE.equals(existing.getIsPublished())) {
+        throw new AlreadyPublishedException("Use the reopen endpoint to modify a published score");
+      }
+
+      InstructorScore target =
+          existing != null
+              ? existing
+              : InstructorScore.builder()
+                  .assignment(assignment)
+                  .student(student)
+                  .enteredBy(actor)
+                  .enteredAt(Instant.now())
+                  .isPublished(false)
+                  .build();
+      target.setScore(row.score());
+      target.setMaxScore(assignment.getMaxScore());
+      target.setComment(row.comment());
+      target.setUpdatedAt(Instant.now());
+      scores.add(target);
+    }
+    return scores;
+  }
+
+  public void afterCsvImportCommitted(Long courseId, Long actorId, int rowCount) {
+    auditService.log(
+        actorId,
+        "INSTRUCTOR_SCORE_CSV_IMPORTED",
+        "Course",
+        courseId,
+        "Committed " + rowCount + " instructor scores from CSV import",
+        null);
+    gradeCalculationService.evictCourseGradeCaches(courseId);
   }
 
   @Transactional

--- a/src/main/java/com/reviewflow/messaging/repository/MessageRepository.java
+++ b/src/main/java/com/reviewflow/messaging/repository/MessageRepository.java
@@ -3,6 +3,7 @@ package com.reviewflow.messaging.repository;
 import com.reviewflow.shared.domain.Message;
 import java.util.Collection;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -103,6 +104,6 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
   @EntityGraph(attributePaths = {"sender", "attachments"})
   @Query(
       "SELECT m FROM Message m WHERE m.conversation.id = :conversationId ORDER BY m.sentAt ASC, m.id ASC")
-  List<Message> findAllByConversationIdForModerationWithDetails(
-      @Param("conversationId") Long conversationId);
+  Page<Message> findAllByConversationIdForModerationWithDetails(
+      @Param("conversationId") Long conversationId, Pageable pageable);
 }

--- a/src/main/java/com/reviewflow/messaging/service/MessagingService.java
+++ b/src/main/java/com/reviewflow/messaging/service/MessagingService.java
@@ -518,11 +518,13 @@ public class MessagingService {
   }
 
   @Transactional(readOnly = true)
-  public List<MessageDto> listMessagesForModeration(Long conversationId) {
+  public org.springframework.data.domain.Page<MessageDto> listMessagesForModeration(
+      Long conversationId, int page, int size) {
     loadConversation(conversationId);
-    List<Message> msgs =
-        messageRepository.findAllByConversationIdForModerationWithDetails(conversationId);
-    return msgs.stream().map(m -> toMessageDto(m, true, true)).collect(Collectors.toList());
+    var messages =
+        messageRepository.findAllByConversationIdForModerationWithDetails(
+            conversationId, org.springframework.data.domain.PageRequest.of(page, size));
+    return messages.map(m -> toMessageDto(m, true, true));
   }
 
   private Conversation loadConversation(Long id) {

--- a/src/main/java/com/reviewflow/shared/domain/Conversation.java
+++ b/src/main/java/com/reviewflow/shared/domain/Conversation.java
@@ -51,7 +51,9 @@ public class Conversation {
   @Column(name = "created_at", nullable = false)
   private Instant createdAt;
 
-  @OneToMany(mappedBy = "conversation", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(
+      mappedBy = "conversation",
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private Set<ConversationParticipant> participants = new HashSet<>();
 }

--- a/src/main/java/com/reviewflow/shared/domain/Course.java
+++ b/src/main/java/com/reviewflow/shared/domain/Course.java
@@ -43,11 +43,15 @@ public class Course {
   @Column(name = "created_at")
   private Instant createdAt;
 
-  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(
+      mappedBy = "course",
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private Set<CourseInstructor> instructors = new HashSet<>();
 
-  @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(
+      mappedBy = "course",
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private Set<CourseEnrollment> enrollments = new HashSet<>();
 }

--- a/src/main/java/com/reviewflow/shared/domain/Evaluation.java
+++ b/src/main/java/com/reviewflow/shared/domain/Evaluation.java
@@ -54,6 +54,10 @@ public class Evaluation {
   @Column(name = "created_at")
   private Instant createdAt;
 
+  @Version
+  @Column(name = "lock_version")
+  private Long lockVersion;
+
   @OneToMany(mappedBy = "evaluation", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<RubricScore> rubricScores = new ArrayList<>();

--- a/src/main/java/com/reviewflow/shared/domain/ExtensionRequest.java
+++ b/src/main/java/com/reviewflow/shared/domain/ExtensionRequest.java
@@ -20,6 +20,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -79,6 +80,10 @@ public class ExtensionRequest {
 
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
+
+  @Version
+  @Column(name = "lock_version")
+  private Long lockVersion;
 
   @PrePersist
   protected void onCreate() {

--- a/src/main/java/com/reviewflow/shared/domain/InstructorScore.java
+++ b/src/main/java/com/reviewflow/shared/domain/InstructorScore.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
@@ -82,4 +83,8 @@ public class InstructorScore {
 
   @Column(name = "updated_at", nullable = false)
   private Instant updatedAt;
+
+  @Version
+  @Column(name = "lock_version")
+  private Long lockVersion;
 }

--- a/src/main/java/com/reviewflow/shared/domain/RubricScore.java
+++ b/src/main/java/com/reviewflow/shared/domain/RubricScore.java
@@ -32,4 +32,8 @@ public class RubricScore {
 
   @Column(columnDefinition = "TEXT")
   private String comment;
+
+  @Version
+  @Column(name = "lock_version")
+  private Long lockVersion;
 }

--- a/src/main/java/com/reviewflow/shared/domain/Submission.java
+++ b/src/main/java/com/reviewflow/shared/domain/Submission.java
@@ -58,4 +58,26 @@ public class Submission {
   @Column(name = "is_late", nullable = false)
   @Builder.Default
   private Boolean isLate = false;
+
+  @Version
+  @Column(name = "lock_version")
+  private Long lockVersion;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @PrePersist
+  protected void onCreate() {
+    Instant now = Instant.now();
+    this.createdAt = now;
+    this.updatedAt = now;
+  }
+
+  @PreUpdate
+  protected void onUpdate() {
+    this.updatedAt = Instant.now();
+  }
 }

--- a/src/main/java/com/reviewflow/shared/domain/Team.java
+++ b/src/main/java/com/reviewflow/shared/domain/Team.java
@@ -40,7 +40,9 @@ public class Team {
   @Column(name = "created_at")
   private Instant createdAt;
 
-  @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(
+      mappedBy = "team",
+      cascade = {CascadeType.PERSIST, CascadeType.MERGE})
   @Builder.Default
   private List<TeamMember> members = new ArrayList<>();
 }

--- a/src/main/java/com/reviewflow/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/reviewflow/shared/exception/GlobalExceptionHandler.java
@@ -57,8 +57,11 @@ import com.reviewflow.system.exception.UnknownCacheException;
 import com.reviewflow.team.exception.TeamNotFoundException;
 import com.reviewflow.shared.dto.ValidationFieldError;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -962,6 +965,31 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
   }
 
+  @ExceptionHandler(OptimisticLockingFailureException.class)
+  public ResponseEntity<ErrorResponse> handleOptimisticLockingFailure(
+      OptimisticLockingFailureException ex) {
+    Long currentVersion = extractCurrentVersion(ex);
+    Map<String, Object> details = new LinkedHashMap<>();
+    if (currentVersion != null) {
+      details.put("currentVersion", currentVersion);
+    }
+    details.put("conflictedAt", Instant.now().toString());
+
+    ErrorResponse body =
+        ErrorResponse.builder()
+            .error(
+                ErrorResponse.ErrorDetail.builder()
+                    .code("CONCURRENT_MODIFICATION")
+                    .message(
+                        "This record was modified by another user. "
+                            + "Please review the latest version and resubmit.")
+                    .details(details)
+                    .build())
+            .timestamp(Instant.now())
+            .build();
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+  }
+
   @ExceptionHandler(DiscussionException.class)
   public ResponseEntity<ApiResponse<Object>> handleDiscussion(DiscussionException ex) {
     ApiResponse<Object> body =
@@ -983,6 +1011,10 @@ public class GlobalExceptionHandler {
             .timestamp(Instant.now())
             .build();
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(body);
+  }
+
+  private static Long extractCurrentVersion(OptimisticLockingFailureException ex) {
+    return null;
   }
 
   private static ResponseEntity<ErrorResponse> errorResponse(

--- a/src/main/java/com/reviewflow/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/reviewflow/submission/repository/SubmissionRepository.java
@@ -3,6 +3,8 @@ package com.reviewflow.submission.repository;
 import com.reviewflow.shared.domain.Submission;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -53,8 +55,8 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
           )
       ORDER BY t.name ASC
       """)
-  List<Submission> findLatestTeamSubmissionsByAssignmentId(
-      @Param("assignmentId") Long assignmentId);
+  Page<Submission> findLatestTeamSubmissionsByAssignmentId(
+      @Param("assignmentId") Long assignmentId, Pageable pageable);
 
   @Query(
       """
@@ -71,8 +73,41 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
           )
       ORDER BY st.lastName ASC, st.firstName ASC
       """)
-  List<Submission> findLatestIndividualSubmissionsByAssignmentId(
-      @Param("assignmentId") Long assignmentId);
+  Page<Submission> findLatestIndividualSubmissionsByAssignmentId(
+      @Param("assignmentId") Long assignmentId, Pageable pageable);
+
+  @Query(
+      """
+      SELECT s
+      FROM Submission s
+      WHERE s.assignment.id IN :assignmentIds
+          AND s.student.id IN :studentIds
+          AND s.versionNumber = (
+              SELECT MAX(s2.versionNumber)
+              FROM Submission s2
+              WHERE s2.assignment.id = s.assignment.id
+                  AND s2.student.id = s.student.id
+          )
+      """)
+  List<Submission> findLatestByAssignmentIdsAndStudentIds(
+      @Param("assignmentIds") List<Long> assignmentIds,
+      @Param("studentIds") List<Long> studentIds);
+
+  @Query(
+      """
+      SELECT s
+      FROM Submission s
+      WHERE s.assignment.id IN :assignmentIds
+          AND s.team.id IN :teamIds
+          AND s.versionNumber = (
+              SELECT MAX(s2.versionNumber)
+              FROM Submission s2
+              WHERE s2.assignment.id = s.assignment.id
+                  AND s2.team.id = s.team.id
+          )
+      """)
+  List<Submission> findLatestByAssignmentIdsAndTeamIds(
+      @Param("assignmentIds") List<Long> assignmentIds, @Param("teamIds") List<Long> teamIds);
 
   @Query(
       "SELECT s FROM Submission s WHERE s.team.id IN (SELECT tm.team.id FROM TeamMember tm WHERE"

--- a/src/main/java/com/reviewflow/system/controller/SystemController.java
+++ b/src/main/java/com/reviewflow/system/controller/SystemController.java
@@ -150,14 +150,18 @@ public class SystemController {
   @Operation(summary = "List conversation messages (moderation)")
   public ResponseEntity<ApiResponse<Map<String, Object>>> moderationListConversationMessages(
       @PathVariable String conversationId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "50") int size,
       Authentication authentication,
       HttpServletRequest request) {
     Long convId = hashidService.decodeOrThrow(conversationId);
     Long actorId = extractUserIdFromAuthentication(authentication);
-    return ResponseEntity.ok(
-        ApiResponse.ok(
-            systemService.moderationListConversationMessages(
-                convId, actorId, clientIp(request))));
+    var messages =
+        systemService.moderationListConversationMessages(
+            convId, actorId, clientIp(request), page, size);
+    return ResponseEntity.ok()
+        .headers(com.reviewflow.shared.util.PaginationHeaders.forPage(messages))
+        .body(ApiResponse.ok(java.util.Map.of("messages", messages.getContent())));
   }
 
   /** PRD-09 Flow D: Get security events */

--- a/src/main/java/com/reviewflow/system/service/SystemMessagingService.java
+++ b/src/main/java/com/reviewflow/system/service/SystemMessagingService.java
@@ -24,8 +24,9 @@ public class SystemMessagingService {
   }
 
   @Transactional(readOnly = true)
-  public List<MessageDto> getConversationMessages(Long conversationId, Long actorId) {
-    return messagingService.listMessagesForModeration(conversationId);
+  public org.springframework.data.domain.Page<MessageDto> getConversationMessages(
+      Long conversationId, Long actorId, int page, int size) {
+    return messagingService.listMessagesForModeration(conversationId, page, size);
   }
 
   public Map<String, Object> getCourseConversationsForApi(Long courseId, Long actorId, String ip) {
@@ -40,16 +41,16 @@ public class SystemMessagingService {
     return Map.of("conversations", list);
   }
 
-  public Map<String, Object> getConversationMessagesForApi(
-      Long conversationId, Long actorId, String ip) {
-    List<MessageDto> messages = getConversationMessages(conversationId, actorId);
+  public org.springframework.data.domain.Page<MessageDto> getConversationMessagesForApi(
+      Long conversationId, Long actorId, String ip, int page, int size) {
+    var messages = getConversationMessages(conversationId, actorId, page, size);
     auditService.log(
         actorId,
         "CONVERSATION_VIEWED",
         "CONVERSATION",
         conversationId,
-        Map.of("conversationId", conversationId),
+        Map.of("conversationId", conversationId, "page", page, "size", size),
         ip);
-    return Map.of("messages", messages);
+    return messages;
   }
 }

--- a/src/main/java/com/reviewflow/system/service/SystemService.java
+++ b/src/main/java/com/reviewflow/system/service/SystemService.java
@@ -467,9 +467,11 @@ public class SystemService {
   }
 
   /** PRD-18: SYSTEM_ADMIN moderation — full message history including soft-deleted. */
-  public java.util.Map<String, Object> moderationListConversationMessages(
-      Long conversationId, Long actorId, String ip) {
-    return systemMessagingService.getConversationMessagesForApi(conversationId, actorId, ip);
+  public org.springframework.data.domain.Page<com.reviewflow.messaging.dto.response.MessageDto>
+      moderationListConversationMessages(
+          Long conversationId, Long actorId, String ip, int page, int size) {
+    return systemMessagingService.getConversationMessagesForApi(
+        conversationId, actorId, ip, page, size);
   }
 
   /** Build a JSON snapshot of evaluation scores for audit trail */

--- a/src/main/java/com/reviewflow/team/repository/TeamRepository.java
+++ b/src/main/java/com/reviewflow/team/repository/TeamRepository.java
@@ -1,6 +1,7 @@
 package com.reviewflow.team.repository;
 
 import com.reviewflow.shared.domain.Team;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,27 @@ import org.springframework.data.repository.query.Param;
 public interface TeamRepository extends JpaRepository<Team, Long> {
 
   List<Team> findByAssignmentId(Long assignmentId);
+
+  @Query(
+      """
+      SELECT DISTINCT t FROM Team t
+      LEFT JOIN FETCH t.members m
+      LEFT JOIN FETCH m.user
+      WHERE t.assignment.id = :assignmentId
+      """)
+  List<Team> findByAssignmentIdWithMembers(@Param("assignmentId") Long assignmentId);
+
+  @Query(
+      """
+      SELECT DISTINCT t
+      FROM Team t
+      JOIN FETCH t.members m
+      JOIN FETCH m.user
+      WHERE t.assignment.id IN :assignmentIds
+          AND m.user.id IN :userIds
+      """)
+  List<Team> findByAssignmentIdsAndMemberUserIds(
+      @Param("assignmentIds") List<Long> assignmentIds, @Param("userIds") List<Long> userIds);
 
   @Query(
       "SELECT t FROM Team t JOIN t.members m WHERE t.assignment.id = :assignmentId AND m.user.id ="

--- a/src/main/java/com/reviewflow/user/repository/UserRepository.java
+++ b/src/main/java/com/reviewflow/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.reviewflow.user.repository;
 
 import com.reviewflow.shared.domain.User;
 import com.reviewflow.shared.domain.UserRole;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +15,8 @@ import org.springframework.data.repository.query.Param;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
+
+  List<User> findByEmailIn(Collection<String> emails);
 
   @Query("SELECT u.emailNotificationsEnabled FROM User u WHERE u.email = :email")
   Optional<Boolean> findEmailPreferenceByEmail(@Param("email") String email);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,10 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=${JPA_SHOW_SQL:false}
 spring.jpa.properties.hibernate.format_sql=${JPA_FORMAT_SQL:false}
+spring.jpa.properties.hibernate.jdbc.batch_size=${HIBERNATE_BATCH_SIZE:50}
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.generate_statistics=${HIBERNATE_STATS:false}
 
 # \u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550
 # FLYWAY

--- a/src/main/resources/db/migration/V35__db_integrity_hardening.sql
+++ b/src/main/resources/db/migration/V35__db_integrity_hardening.sql
@@ -1,0 +1,37 @@
+-- V35__db_integrity_hardening.sql
+-- Database integrity hardening: optimistic locking, missing indexes,
+-- cascade safety, and audit timestamps.
+-- After V34 (discussions). PRD-16 content delivery moves to V36.
+
+-- Phase 1: Optimistic locking columns
+ALTER TABLE submissions
+    ADD COLUMN lock_version BIGINT NOT NULL DEFAULT 0
+    COMMENT 'JPA optimistic lock version — distinct from versionNumber (document revision)';
+
+ALTER TABLE evaluations
+    ADD COLUMN lock_version BIGINT NOT NULL DEFAULT 0
+    COMMENT 'JPA optimistic lock version';
+
+ALTER TABLE instructor_scores
+    ADD COLUMN lock_version BIGINT NOT NULL DEFAULT 0
+    COMMENT 'JPA optimistic lock version';
+
+ALTER TABLE rubric_scores
+    ADD COLUMN lock_version BIGINT NOT NULL DEFAULT 0
+    COMMENT 'JPA optimistic lock version';
+
+ALTER TABLE extension_requests
+    ADD COLUMN lock_version BIGINT NOT NULL DEFAULT 0
+    COMMENT 'JPA optimistic lock version';
+
+-- Phase 2: Missing indexes
+CREATE INDEX idx_conv_course ON conversations(course_id);
+
+-- Phase 3: Submission audit timestamps
+ALTER TABLE submissions
+    ADD COLUMN created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    ADD COLUMN updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6);
+
+UPDATE submissions
+SET created_at = COALESCE(uploaded_at, created_at),
+    updated_at = COALESCE(uploaded_at, updated_at);

--- a/src/test/java/com/reviewflow/grading/service/CsvImportCommitServiceTest.java
+++ b/src/test/java/com/reviewflow/grading/service/CsvImportCommitServiceTest.java
@@ -1,0 +1,120 @@
+package com.reviewflow.grading.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.reviewflow.assignment.repository.AssignmentRepository;
+import com.reviewflow.grading.job.JobState;
+import com.reviewflow.grading.job.JobStatus;
+import com.reviewflow.grading.job.ValidatedRow;
+import com.reviewflow.grading.repository.InstructorScoreRepository;
+import com.reviewflow.infrastructure.jobs.AsyncJobService;
+import com.reviewflow.infrastructure.storage.S3Service;
+import com.reviewflow.shared.domain.Assignment;
+import com.reviewflow.shared.domain.Course;
+import com.reviewflow.shared.domain.InstructorScore;
+import com.reviewflow.shared.domain.SubmissionType;
+import com.reviewflow.shared.domain.User;
+import com.reviewflow.shared.util.HashidService;
+import com.reviewflow.user.repository.UserRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CsvImportCommitServiceTest {
+
+  @Mock private AsyncJobService asyncJobService;
+  @Mock private S3Service s3Service;
+  @Mock private AssignmentRepository assignmentRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private InstructorScoreRepository instructorScoreRepository;
+  @Mock private InstructorScoreService instructorScoreService;
+  @Mock private HashidService hashidService;
+
+  private CsvImportCommitService commitService;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @BeforeEach
+  void setUp() {
+    commitService =
+        new CsvImportCommitService(
+            asyncJobService,
+            s3Service,
+            objectMapper,
+            assignmentRepository,
+            userRepository,
+            instructorScoreRepository,
+            instructorScoreService,
+            hashidService);
+  }
+
+  @Test
+  void commitJob_individualMode_usesSingleEmailLookupAndSaveAll() throws Exception {
+    String jobId = "job-1";
+    JobState state =
+        new JobState(
+            jobId,
+            JobStatus.VALIDATION_PASSED,
+            "a1",
+            "u1",
+            "c1",
+            2,
+            2,
+            0,
+            2,
+            "src",
+            "validated",
+            null,
+            null,
+            Instant.now(),
+            Instant.now());
+    when(asyncJobService.getJob(jobId)).thenReturn(Optional.of(state));
+    when(hashidService.decodeOrThrow("a1")).thenReturn(10L);
+    when(hashidService.decodeOrThrow("u1")).thenReturn(20L);
+
+    List<ValidatedRow> rows =
+        List.of(
+            new ValidatedRow("s1@test.com", null, BigDecimal.TEN, "c1"),
+            new ValidatedRow("s2@test.com", null, BigDecimal.ONE, "c2"));
+    when(s3Service.getObject("validated"))
+        .thenReturn(objectMapper.writeValueAsBytes(rows));
+
+    Course course = Course.builder().id(99L).build();
+    Assignment assignment =
+        Assignment.builder()
+            .id(10L)
+            .course(course)
+            .submissionType(SubmissionType.INSTRUCTOR_GRADED)
+            .maxScore(BigDecimal.valueOf(100))
+            .build();
+    when(assignmentRepository.findWithDetailsById(10L)).thenReturn(Optional.of(assignment));
+
+    User u1 = User.builder().id(1L).email("s1@test.com").build();
+    User u2 = User.builder().id(2L).email("s2@test.com").build();
+    when(userRepository.findByEmailIn(any())).thenReturn(List.of(u1, u2));
+
+    InstructorScore score1 = InstructorScore.builder().assignment(assignment).student(u1).build();
+    InstructorScore score2 = InstructorScore.builder().assignment(assignment).student(u2).build();
+    when(instructorScoreService.buildScoresForCsvImport(eq(10L), eq(20L), eq(rows), any()))
+        .thenReturn(List.of(score1, score2));
+
+    commitService.commitJob(jobId);
+
+    verify(userRepository, never()).findByEmail(any());
+    verify(userRepository).findByEmailIn(any());
+    verify(instructorScoreRepository).saveAll(anyList());
+    verify(instructorScoreService).afterCsvImportCommitted(99L, 20L, 2);
+  }
+}

--- a/src/test/java/com/reviewflow/grading/service/GradeCalculationServiceTest.java
+++ b/src/test/java/com/reviewflow/grading/service/GradeCalculationServiceTest.java
@@ -215,37 +215,19 @@ class GradeCalculationServiceTest {
     AssignmentGroup group = group(10L, "Exams", 100, 0, List.of(assignment));
     when(assignmentGroupRepository.findDetailedByCourseId(courseId)).thenReturn(List.of(group));
 
-    when(teamRepository.findByAssignmentIdsAndMemberUserId(anyList(), eq(101L)))
-        .thenReturn(List.of());
-    when(teamRepository.findByAssignmentIdsAndMemberUserId(anyList(), eq(102L)))
+    when(teamRepository.findByAssignmentIdsAndMemberUserIds(anyList(), anyList()))
         .thenReturn(List.of());
 
     Submission lowSubmission = submission(1001L, assignment, 101L);
     Submission highSubmission = submission(1002L, assignment, 102L);
-    when(submissionRepository.findLatestByAssignmentIdsAndStudentId(anyList(), eq(101L)))
-        .thenReturn(List.of(lowSubmission));
-    when(submissionRepository.findLatestByAssignmentIdsAndStudentId(anyList(), eq(102L)))
-        .thenReturn(List.of(highSubmission));
+    when(submissionRepository.findLatestByAssignmentIdsAndStudentIds(anyList(), anyList()))
+        .thenReturn(List.of(lowSubmission, highSubmission));
 
     Evaluation lowEval = evaluation(2001L, lowSubmission, 60);
     Evaluation highEval = evaluation(2002L, highSubmission, 90);
     when(evaluationRepository.findPublishedFinalBySubmissionIds(anyList()))
-        .thenAnswer(
-            invocation -> {
-              List<Long> submissionIds = invocation.getArgument(0);
-              if (submissionIds.contains(1001L)) {
-                return List.of(lowEval);
-              }
-              if (submissionIds.contains(1002L)) {
-                return List.of(highEval);
-              }
-              return List.of();
-            });
-    when(instructorScoreRepository.findByAssignmentIdInAndStudentIdAndIsPublishedTrue(
-            anyList(), eq(101L)))
-        .thenReturn(List.of());
-    when(instructorScoreRepository.findByAssignmentIdInAndStudentIdAndIsPublishedTrue(
-            anyList(), eq(102L)))
+        .thenReturn(List.of(lowEval, highEval));
+    when(instructorScoreRepository.findPublishedByAssignmentIdsAndStudentIds(anyList(), anyList()))
         .thenReturn(List.of());
 
     ClassRosterDto roster =

--- a/src/test/java/com/reviewflow/grading/service/GradeExportServiceTest.java
+++ b/src/test/java/com/reviewflow/grading/service/GradeExportServiceTest.java
@@ -103,8 +103,8 @@ class GradeExportServiceTest {
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
     when(courseInstructorRepository.existsByCourseIdAndUserId(courseId, actorId))
         .thenReturn(true);
-    when(submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of(submission));
+    when(submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(submission)));
     when(evaluationRepository.findPublishedBySubmissionIds(List.of(501L)))
         .thenReturn(List.of(evaluation));
     when(teamMemberRepository.findByTeamIdsAndStatusWithUser(
@@ -152,8 +152,8 @@ class GradeExportServiceTest {
     when(hashidService.decodeOrThrow("A21")).thenReturn(assignmentId);
     when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
-    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of(submission));
+    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(submission)));
     when(evaluationRepository.findPublishedBySubmissionIds(List.of(700L))).thenReturn(List.of());
 
     GradeExportService.ExportResult result = gradeExportService.export("C10", "A21", actorId);
@@ -208,8 +208,8 @@ class GradeExportServiceTest {
     when(hashidService.decodeOrThrow("A20")).thenReturn(assignmentId);
     when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
-    when(submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of());
+    when(submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(org.springframework.data.domain.Page.empty());
 
     assertThrows(
         NoSubmissionsFoundException.class, () -> gradeExportService.export("C10", "A20", actorId));
@@ -247,8 +247,8 @@ class GradeExportServiceTest {
     when(hashidService.decodeOrThrow("A30")).thenReturn(assignmentId);
     when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
-    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of(submission));
+    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(submission)));
     when(evaluationRepository.findPublishedBySubmissionIds(List.of(702L))).thenReturn(List.of());
 
     GradeExportService.ExportResult result = gradeExportService.export("C20", "A30", actorId);
@@ -292,8 +292,8 @@ class GradeExportServiceTest {
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
     when(courseInstructorRepository.existsByCourseIdAndUserId(courseId, actorId))
         .thenReturn(true);
-    when(submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of(submission));
+    when(submissionRepository.findLatestTeamSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(submission)));
     when(evaluationRepository.findPublishedBySubmissionIds(List.of(501L)))
         .thenReturn(List.of(evaluation));
     when(teamMemberRepository.findByTeamIdsAndStatusWithUser(
@@ -327,8 +327,8 @@ class GradeExportServiceTest {
     when(hashidService.decodeOrThrow("A31")).thenReturn(assignmentId);
     when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
-    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of());
+    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(org.springframework.data.domain.Page.empty());
 
     assertThrows(
         NoSubmissionsFoundException.class, () -> gradeExportService.export("C10", "A31", actorId));
@@ -410,8 +410,8 @@ class GradeExportServiceTest {
     when(hashidService.decodeOrThrow("A32")).thenReturn(assignmentId);
     when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
-    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of(sub1, sub2, sub3, sub4));
+    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(sub1, sub2, sub3, sub4)));
     when(evaluationRepository.findPublishedBySubmissionIds(List.of(1L, 2L, 3L, 4L)))
         .thenReturn(List.of());
 
@@ -483,8 +483,8 @@ class GradeExportServiceTest {
     when(hashidService.decodeOrThrow("A33")).thenReturn(assignmentId);
     when(assignmentRepository.findById(assignmentId)).thenReturn(Optional.of(assignment));
     when(userRepository.findById(actorId)).thenReturn(Optional.of(actor));
-    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId))
-        .thenReturn(List.of(sub1, sub2));
+    when(submissionRepository.findLatestIndividualSubmissionsByAssignmentId(assignmentId, org.springframework.data.domain.Pageable.unpaged()))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(sub1, sub2)));
     when(evaluationRepository.findPublishedBySubmissionIds(List.of(1L, 2L)))
         .thenReturn(List.of(publishedEval));
 

--- a/src/test/java/com/reviewflow/integration/DbIntegrityHardeningIntegrationTest.java
+++ b/src/test/java/com/reviewflow/integration/DbIntegrityHardeningIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.reviewflow.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+      "spring.flyway.validate-on-migrate=false",
+      "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration"
+    })
+class DbIntegrityHardeningIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private com.reviewflow.evaluation.repository.EvaluationRepository evaluationRepository;
+  @Autowired private com.reviewflow.submission.repository.SubmissionRepository submissionRepository;
+  @Autowired private com.reviewflow.grading.repository.InstructorScoreRepository instructorScoreRepository;
+  @Autowired private com.reviewflow.grading.repository.RubricScoreRepository rubricScoreRepository;
+  @Autowired private com.reviewflow.extension.repository.ExtensionRequestRepository extensionRequestRepository;
+
+  @Test
+  void lockVersionColumn_existsOnAllFiveTables() {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME IN ('submissions','evaluations','instructor_scores','rubric_scores','extension_requests')
+              AND COLUMN_NAME = 'lock_version'
+            """,
+            Integer.class);
+    assertEquals(5, count);
+  }
+
+  @Test
+  void idx_conv_course_exists() {
+    Integer count =
+        jdbcTemplate.queryForObject(
+            """
+            SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE()
+              AND TABLE_NAME = 'conversations'
+              AND INDEX_NAME = 'idx_conv_course'
+            """,
+            Integer.class);
+    assertEquals(1, count);
+  }
+
+  @Test
+  @Transactional
+  void evaluation_concurrentUpdate_throwsOptimisticLockingFailure() {
+    Long id =
+        jdbcTemplate.queryForObject("SELECT id FROM evaluations ORDER BY id ASC LIMIT 1", Long.class);
+    var first = evaluationRepository.findById(id).orElseThrow();
+    var second = evaluationRepository.findById(id).orElseThrow();
+    first.setTotalScore(BigDecimal.valueOf(80));
+    evaluationRepository.saveAndFlush(first);
+    second.setTotalScore(BigDecimal.valueOf(90));
+    assertThrows(OptimisticLockingFailureException.class, () -> evaluationRepository.saveAndFlush(second));
+  }
+
+  @Test
+  @Transactional
+  void submission_concurrentUpdate_throwsOptimisticLockingFailure() {
+    Long id =
+        jdbcTemplate.queryForObject("SELECT id FROM submissions ORDER BY id ASC LIMIT 1", Long.class);
+    var first = submissionRepository.findById(id).orElseThrow();
+    var second = submissionRepository.findById(id).orElseThrow();
+    first.setChangeNote("first");
+    submissionRepository.saveAndFlush(first);
+    second.setChangeNote("second");
+    assertThrows(OptimisticLockingFailureException.class, () -> submissionRepository.saveAndFlush(second));
+  }
+
+  @Test
+  @Transactional
+  void instructorScore_concurrentUpdate_throwsOptimisticLockingFailure() {
+    Long id =
+        jdbcTemplate.queryForObject(
+            "SELECT id FROM instructor_scores ORDER BY id ASC LIMIT 1", Long.class);
+    var first = instructorScoreRepository.findById(id).orElseThrow();
+    var second = instructorScoreRepository.findById(id).orElseThrow();
+    first.setComment("first");
+    instructorScoreRepository.saveAndFlush(first);
+    second.setComment("second");
+    assertThrows(
+        OptimisticLockingFailureException.class, () -> instructorScoreRepository.saveAndFlush(second));
+  }
+
+  @Test
+  @Transactional
+  void rubricScore_concurrentUpdate_throwsOptimisticLockingFailure() {
+    Long id =
+        jdbcTemplate.queryForObject("SELECT id FROM rubric_scores ORDER BY id ASC LIMIT 1", Long.class);
+    var first = rubricScoreRepository.findById(id).orElseThrow();
+    var second = rubricScoreRepository.findById(id).orElseThrow();
+    first.setComment("first");
+    rubricScoreRepository.saveAndFlush(first);
+    second.setComment("second");
+    assertThrows(OptimisticLockingFailureException.class, () -> rubricScoreRepository.saveAndFlush(second));
+  }
+
+  @Test
+  @Transactional
+  void extensionRequest_concurrentUpdate_throwsOptimisticLockingFailure() {
+    Long id =
+        jdbcTemplate.queryForObject(
+            "SELECT id FROM extension_requests ORDER BY id ASC LIMIT 1", Long.class);
+    var first = extensionRequestRepository.findById(id).orElseThrow();
+    var second = extensionRequestRepository.findById(id).orElseThrow();
+    first.setReason("first");
+    extensionRequestRepository.saveAndFlush(first);
+    second.setReason("second");
+    assertThrows(
+        OptimisticLockingFailureException.class, () -> extensionRequestRepository.saveAndFlush(second));
+  }
+}

--- a/src/test/java/com/reviewflow/messaging/service/MessagingServiceTest.java
+++ b/src/test/java/com/reviewflow/messaging/service/MessagingServiceTest.java
@@ -834,15 +834,16 @@ class MessagingServiceTest {
             .sentAt(Instant.now())
             .attachments(new ArrayList<>())
             .build();
-    when(messageRepository.findAllByConversationIdForModerationWithDetails(CONV_ID))
-        .thenReturn(List.of(deleted));
+    when(messageRepository.findAllByConversationIdForModerationWithDetails(
+            eq(CONV_ID), any(org.springframework.data.domain.Pageable.class)))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(List.of(deleted)));
     when(hashidService.encode(anyLong())).thenAnswer(inv -> "h" + inv.getArgument(0));
 
-    var dtos = messagingService.listMessagesForModeration(CONV_ID);
+    var page = messagingService.listMessagesForModeration(CONV_ID, 0, 50);
 
-    assertEquals(1, dtos.size());
-    assertEquals("removed text", dtos.get(0).getContent());
-    assertTrue(dtos.get(0).isDeleted());
+    assertEquals(1, page.getContent().size());
+    assertEquals("removed text", page.getContent().get(0).getContent());
+    assertTrue(page.getContent().get(0).isDeleted());
   }
 
   @Test

--- a/src/test/java/com/reviewflow/shared/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/reviewflow/shared/exception/GlobalExceptionHandlerTest.java
@@ -31,7 +31,9 @@ import com.reviewflow.shared.exception.StorageNotFoundException;
 import com.reviewflow.user.exception.AvatarInvalidTypeException;
 import com.reviewflow.user.exception.AvatarNotFoundException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -309,5 +311,15 @@ class GlobalExceptionHandlerTest {
 
     assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
     assertEquals("COURSE_NOT_OWNED", response.getBody().getError().getCode());
+  }
+
+  @Test
+  void optimisticLockingFailure_mapsTo409WithConcurrentModification() {
+    ResponseEntity<ErrorResponse> response =
+        handler.handleOptimisticLockingFailure(new OptimisticLockingFailureException("stale"));
+
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+    assertEquals("CONCURRENT_MODIFICATION", response.getBody().getError().getCode());
+    assertNotNull(response.getBody().getError().getDetails().get("conflictedAt"));
   }
 }

--- a/src/test/java/com/reviewflow/system/controller/SystemControllerMessagingTest.java
+++ b/src/test/java/com/reviewflow/system/controller/SystemControllerMessagingTest.java
@@ -77,11 +77,15 @@ class SystemControllerMessagingTest {
     when(request.getHeader("X-Forwarded-For")).thenReturn(null);
     when(request.getRemoteAddr()).thenReturn("127.0.0.1");
     when(hashidService.decodeOrThrow("CNV1")).thenReturn(55L);
-    when(systemService.moderationListConversationMessages(eq(55L), eq(1L), eq("127.0.0.1")))
-        .thenReturn(Map.of("messages", List.of(MessageDto.builder().id("m1").build())));
+    var messagePage =
+        new org.springframework.data.domain.PageImpl<>(
+            List.of(MessageDto.builder().id("m1").build()));
+    when(systemService.moderationListConversationMessages(
+            eq(55L), eq(1L), eq("127.0.0.1"), eq(0), eq(50)))
+        .thenReturn(messagePage);
 
     ResponseEntity<com.reviewflow.shared.exception.ApiResponse<Map<String, Object>>> response =
-        controller().moderationListConversationMessages("CNV1", adminAuth(), request);
+        controller().moderationListConversationMessages("CNV1", 0, 50, adminAuth(), request);
 
     assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(1, ((List<?>) response.getBody().getData().get("messages")).size());

--- a/src/test/java/com/reviewflow/system/service/SystemMessagingServiceTest.java
+++ b/src/test/java/com/reviewflow/system/service/SystemMessagingServiceTest.java
@@ -51,19 +51,19 @@ class SystemMessagingServiceTest {
   @Test
   void getConversationMessagesForApi_auditsAndReturnsPayload() {
     List<MessageDto> messages = List.of(MessageDto.builder().id("m1").build());
-    when(messagingService.listMessagesForModeration(55L)).thenReturn(messages);
+    when(messagingService.listMessagesForModeration(55L, 0, 50))
+        .thenReturn(new org.springframework.data.domain.PageImpl<>(messages));
 
-    Map<String, Object> payload =
-        systemMessagingService.getConversationMessagesForApi(55L, 1L, "10.0.0.1");
+    var page = systemMessagingService.getConversationMessagesForApi(55L, 1L, "10.0.0.1", 0, 50);
 
-    assertEquals(messages, payload.get("messages"));
+    assertEquals(messages, page.getContent());
     verify(auditService)
         .log(
             eq(1L),
             eq("CONVERSATION_VIEWED"),
             eq("CONVERSATION"),
             eq(55L),
-            eq(Map.of("conversationId", 55L)),
+            eq(Map.of("conversationId", 55L, "page", 0, "size", 50)),
             eq("10.0.0.1"));
   }
 }


### PR DESCRIPTION
…ixes

Introduce lock_version columns and submission audit timestamps, narrow unsafe JPA cascades, return 409 CONCURRENT_MODIFICATION on stale writes, and replace per-row roster/CSV/gradebook queries with bulk fetches plus paginated endpoints.