### PR TITLE
feat: add AWS Terraform infrastructure and hardening updates

### DIFF
--- a/docs/PRD_15_roster.md
+++ b/docs/PRD_15_roster.md
@@ -1,0 +1,128 @@
+# PRD 15 — Course Roster
+
+**Status:** Draft  
+**Author:** Roqeeb Olamide Ayorinde  
+**Depends on:** PRD-02 (avatar_url exists on users)  
+**Blocks:** Nothing  
+**Migration:** None — permissions change + endpoint update only
+
+---
+
+## Purpose
+
+Students currently have no way to see who else is in their course. Instructors have `GET /courses/{id}/students` but it returns raw data with no formatting, no avatars, and is not accessible to students. This PRD adds a properly structured roster endpoint accessible to all course members with role-appropriate data visibility.
+
+---
+
+## Roles & Permissions
+
+| Action | STUDENT | INSTRUCTOR | ADMIN | SYSTEM_ADMIN |
+|---|---|---|---|---|
+| View course roster | ✓ — own enrolled courses | ✓ — own courses | ✓ | ✓ |
+| See classmate emails | ✗ — privacy | ✓ | ✓ | ✓ |
+| See enrollment date | ✗ | ✓ | ✓ | ✓ |
+| See submission count | ✗ | ✓ | ✓ | ✓ |
+
+---
+
+## Full Request Flow
+
+```
+GET /courses/{id}/roster
+
+→ CourseController.getRoster(courseId, currentUser)
+→ CourseService.getRoster(courseId, userId, role)
+    → Verify user is enrolled in or teaches this course → 403 if not
+    → Fetch instructors: SELECT users WHERE course_instructors.course_id = ?
+    → Fetch students: SELECT users WHERE course_enrollments.course_id = ?
+    → If role == STUDENT:
+        Return limited student view (name + avatar only, no emails)
+    → If role == INSTRUCTOR/ADMIN/SYSTEM_ADMIN:
+        Return full view (name + email + avatar + enrolled_at + submission_count)
+    → submission_count = COUNT(submissions WHERE student_id = userId
+        OR team_id IN (SELECT team_id FROM team_members WHERE user_id = userId))
+
+→ 200 OK { instructors: [...], students: [...], totalStudents: N }
+```
+
+---
+
+## Data Model
+
+No new tables. Uses existing `users`, `course_enrollments`, `course_instructors`.
+
+Deprecate `GET /courses/{id}/students` — replaced by `GET /courses/{id}/roster`. Keep old endpoint returning 301 redirect to `/roster` for backward compatibility.
+
+---
+
+## API Contract
+
+### GET /courses/{id}/roster
+
+**Student view:**
+```json
+{
+  "success": true,
+  "data": {
+    "instructors": [
+      {
+        "id": "usr111",
+        "firstName": "Sarah",
+        "lastName": "Johnson",
+        "avatarUrl": "https://...",
+        "role": "INSTRUCTOR"
+      }
+    ],
+    "students": [
+      {
+        "id": "stu111",
+        "firstName": "Jane",
+        "lastName": "Smith",
+        "avatarUrl": null,
+        "role": "STUDENT"
+      }
+    ],
+    "totalStudents": 20
+  }
+}
+```
+
+**Instructor view (additional fields):**
+```json
+{
+  "students": [
+    {
+      "id": "stu111",
+      "firstName": "Jane",
+      "lastName": "Smith",
+      "email": "jane.smith@university.edu",
+      "avatarUrl": null,
+      "role": "STUDENT",
+      "enrolledAt": "2026-01-15T09:00:00Z",
+      "submissionCount": 4
+    }
+  ]
+}
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|---|---|
+| Student not enrolled in course | 403 FORBIDDEN |
+| Course has no students yet | Returns empty students array |
+| Student has no avatar | avatarUrl: null — frontend shows initials |
+| Instructor teaches multiple sections | Only students in requested course shown |
+
+---
+
+## Impact on Existing Modules
+
+| Module | Change |
+|---|---|
+| `CourseController` | Add `GET /courses/{id}/roster`, deprecate `/students` |
+| `CourseService` | Add `getRoster()` with role-based field filtering |
+| `CourseDto` | Existing — no change |
+| New: `RosterDto`, `RosterMemberDto` | Response shapes |

--- a/docs/agents/websocket-hardening.md
+++ b/docs/agents/websocket-hardening.md
@@ -1,0 +1,521 @@
+# Agent — WebSocket & Realtime Hardening
+
+**Status:** Final  
+**Author:** Roqeeb Olamide Ayorinde  
+**Source:** WebSocket & Realtime Audit Report 2026-05-18 (10 findings)  
+**Tier:** 2 — HIGH findings block production  
+**Migration:** None
+
+---
+
+## How to Invoke This Agent
+
+```
+@docs/agents/websocket-hardening.md fix all
+```
+
+Other commands:
+
+| Command | What it does |
+|---|---|
+| `fix all` | Execute HIGH → MEDIUM → Security Validator in order |
+| `fix high` | HIGH-1 force disconnect only |
+| `fix medium` | MEDIUM-1 and MEDIUM-2 only |
+| `fix validator` | SecurityStartupValidator only |
+| `verify` | Run full verification checklist, no code changes |
+| `status` | Show which tiers are complete and which remain |
+
+---
+
+## Already Covered — Verify Exist, Do Not Re-Implement
+
+Before starting, confirm these exist in the codebase:
+
+| Finding | Covered in |
+|---|---|
+| SUBSCRIBE destination validation | PRD-Security-Auth-Hardening HIGH-4 |
+| WS ticket rate limiting (`AUTH_WS_TICKET`) | PRD-RateLimit-Hardening HIGH-2 |
+| CORS prod property mismatch | PRD-Security-Auth-Hardening CRITICAL-1 |
+
+---
+
+## Agent Instructions — Read Before Starting
+
+You are a senior Spring Boot engineer executing a structured WebSocket and realtime hardening pass on ReviewFlow, a **Spring Boot 4.0.x / Java 21** academic submission and grading platform.
+
+**Rules:**
+- HIGH-1 must be verified before MEDIUM work begins.
+- **Read `WebSocketForceDisconnectListener`, `SubProtocolWebSocketHandler`, and `WebSocketSessionRegistry` before touching any of them.** The hard-disconnect implementation must use whatever raw session access the codebase already provides — do not assume `subProtocolHandler.getWebSocketSessions()` exists.
+- The `SecurityStartupValidator` is an addition to PRD-Security-Auth-Hardening P0-1 — implement it here if it was not already implemented there. Check first.
+- INFO items are deferred — document in RUNBOOK.md only, no code.
+
+**Files likely touched:**
+
+| File | Path |
+|---|---|
+| WebSocketForceDisconnectListener | `infrastructure/websocket/WebSocketForceDisconnectListener.java` |
+| WebSocketConfig | `infrastructure/websocket/WebSocketConfig.java` |
+| SecurityStartupValidator | `infrastructure/config/SecurityStartupValidator.java` (new, if not already exists) |
+| application.properties | `src/main/resources/application.properties` |
+| application-prod.properties | `src/main/resources/application-prod.properties` |
+| RUNBOOK.md | `orchestration/RUNBOOK.md` |
+
+---
+
+## Locked Decisions
+
+| Decision | Choice |
+|---|---|
+| Force logout WS | Four-step sequence: revoke → notify → hard disconnect → 401 on reconnect |
+| SockJS in prod | Property toggle: `websocket.sockjs.enabled=false` in prod |
+| CORS `*` validator | Non-optional `@Profile("prod")` startup validator |
+| Transport limits | 256KB message size, 512KB send buffer, 10s send timeout — all `@Value` backed |
+
+---
+
+## Execution Protocol for `fix all`
+
+```
+STEP 1 — Pre-flight
+  Verify "Already Covered" items exist in codebase
+  Check if SecurityStartupValidator already exists from PRD-Security-Auth-Hardening
+  Read WebSocketForceDisconnectListener fully
+  Read WebSocketSessionRegistry + SubProtocolWebSocketHandler to understand raw session access
+
+STEP 2 — Create fix branch
+  git checkout -b fix/websocket-hardening
+
+STEP 3 — HIGH-1: Force logout four-step sequence
+  Verify before advancing
+
+STEP 4 — MEDIUM-1: Transport size and time limits
+
+STEP 5 — MEDIUM-2: SockJS profile toggle
+
+STEP 6 — Security Startup Validator
+  Skip if already implemented in PRD-Security-Auth-Hardening
+
+STEP 7 — Update RUNBOOK.md with INFO deferred items
+
+STEP 8 — Run full verification checklist
+```
+
+---
+
+## HIGH-1 · WebSocketForceDisconnectListener — Four-Step Force Disconnect
+
+**File:** `infrastructure/websocket/WebSocketForceDisconnectListener.java`  
+**Issue:** Force logout clears the in-memory session registry and pushes `/queue/session-revoked` but does not close transport sessions. A client that ignores the push event can auto-reconnect immediately — it still holds a valid token so the new WebSocket session is accepted.
+
+**The reconnect race — why notify-only is insufficient:**
+
+```
+Force logout triggered
+  → /queue/session-revoked pushed ✓
+  → Client ignores event and auto-reconnects immediately
+  → Client still has valid token (not yet expired)
+  → New WebSocket session accepted
+  → Token expires naturally — minutes or hours later
+```
+
+**Correct four-step sequence — order is mandatory:**
+
+```
+1. Token revoked in auth store       ← closes the reconnect window FIRST
+2. Push /queue/session-revoked       ← well-behaved clients disconnect cleanly
+3. Hard close transport sessions     ← malicious/buggy clients are cut off
+4. Any reconnect attempt hits 401    ← token already invalid, reconnect fails
+```
+
+Step 1 must complete before step 3. Without it, step 3 just delays reconnect by milliseconds.
+
+**Ordering guarantee:** `ForceLogoutEvent` fires in `SystemService.forceLogout()` after `userRepository.incrementTokenVersion(userId)` — which means the token is already invalid in the DB when this listener runs. Both `TokenVersionInvalidatedEvent` and `ForceLogoutEvent` are published in the same service method and handled post-commit via `@TransactionalEventListener(AFTER_COMMIT)`.
+
+**Fix:**
+
+```java
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketForceDisconnectListener {
+
+    private final WebSocketSessionRegistry sessionRegistry;
+    private final WebSocketUserEventService userEventService;
+    private final SimpUserRegistry simpUserRegistry;
+    private final SubProtocolWebSocketHandler subProtocolHandler;
+    // SubProtocolWebSocketHandler manages raw WS sessions
+    // VERIFY: check if getWebSocketSessions() exists before writing
+    // If not: use WebSocketSessionRegistry which may store raw WebSocketSession objects
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleForceDisconnect(ForceLogoutEvent event) {
+        Long userId = event.getUserId();
+        String hashedUserId = event.getHashedUserId();
+
+        log.info("Force disconnect initiated userId={}", hashedUserId);
+
+        // Step 1: Token already revoked before this fires (ordering guarantee above)
+
+        // Step 2: Notify — push /queue/session-revoked for well-behaved clients
+        userEventService.notifySessionsRevoked(userId);
+
+        // Step 3: Hard disconnect — close all transport sessions for this user
+        Set<String> sessionIds = getSessionIds(userId);
+        if (sessionIds.isEmpty()) {
+            log.debug("No active WS sessions for userId={}", hashedUserId);
+        } else {
+            log.info("Closing {} WS sessions for userId={}",
+                sessionIds.size(), hashedUserId);
+            sessionIds.forEach(sessionId -> closeSession(sessionId, hashedUserId));
+        }
+
+        // Step 4: Automatic — any reconnect attempt finds revoked token → 401
+        // (WebSocketAuthInterceptor on CONNECT + JwtAuthenticationFilter)
+
+        // Clear registry AFTER disconnect attempts
+        sessionRegistry.clearUser(userId);
+    }
+
+    private Set<String> getSessionIds(Long userId) {
+        // SimpUserRegistry tracks STOMP-level sessions by principal name
+        // Principal name = raw userId as string (verify from existing implementation)
+        SimpUser simpUser = simpUserRegistry.getUser(String.valueOf(userId));
+        if (simpUser == null) return Set.of();
+        return simpUser.getSessions().stream()
+            .map(SimpSession::getId)
+            .collect(Collectors.toSet());
+    }
+
+    private void closeSession(String sessionId, String hashedUserId) {
+        try {
+            // VERIFY before writing: check whether SubProtocolWebSocketHandler
+            // exposes getWebSocketSessions() or equivalent.
+            // If WebSocketSessionRegistry already stores raw WebSocketSession objects,
+            // use that instead. Read both classes before finalising this method.
+            WebSocketSession rawSession = subProtocolHandler
+                .getWebSocketSessions().get(sessionId);
+            if (rawSession != null && rawSession.isOpen()) {
+                rawSession.close(CloseStatus.POLICY_VIOLATION);
+                // CloseStatus 1008 = POLICY_VIOLATION
+                // Clients must NOT auto-reconnect on 1008 (unlike 1006 abnormal closure)
+                log.debug("WS session closed sessionId={} userId={}",
+                    sessionId, hashedUserId);
+            }
+        } catch (IOException e) {
+            // Session may already be closing — log and continue
+            log.warn("Error closing WS session sessionId={}: {}",
+                sessionId, e.getMessage());
+        }
+    }
+}
+```
+
+**Verify:**
+```
+Force logout via POST /system/force-logout:
+  Step 1: Token version incremented + committed (pre-condition)
+  Step 2: /queue/session-revoked pushed to target user
+  Step 3: All WS sessions closed with CloseStatus 1008 POLICY_VIOLATION
+  Step 4: Client reconnects → WebSocketAuthInterceptor → token version check → 401
+
+No active WS sessions: force logout completes without error (empty set handled)
+IOException on session close: WARN logged, continues to next session (not fatal)
+Client re-establishes session after force-logout: 401 on CONNECT
+```
+
+---
+
+## MEDIUM-1 · WebSocketConfig — Transport Size and Time Limits
+
+**File:** `infrastructure/websocket/WebSocketConfig.java`  
+**Issue:** `configureWebSocketTransport` not overridden. No message size limit, send buffer limit, or send timeout. Large STOMP frames can exhaust JVM heap independently of HTTP multipart limits.
+
+**Read the file first** — verify whether `configureWebSocketTransport` is already overridden. If it is, ensure all three limits are wired and `@Value`-backed.
+
+```java
+// WebSocketConfig.java — add override:
+
+@Value("${websocket.transport.message-size-limit:262144}")   // 256KB default
+private int messageSizeLimitBytes;
+
+@Value("${websocket.transport.send-buffer-size-limit:524288}") // 512KB default
+private int sendBufferSizeLimitBytes;
+
+@Value("${websocket.transport.send-time-limit:10000}")         // 10 seconds default
+private int sendTimeLimitMs;
+
+@Override
+public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+    registration
+        // Max inbound STOMP frame size
+        // ReviewFlow STOMP frames carry notification payloads, message previews (~80 chars),
+        // and job status updates — never raw file bytes (those go through HTTP multipart)
+        // 256KB is generous for all current use cases
+        .setMessageSizeLimit(messageSizeLimitBytes)
+
+        // Max outbound send buffer per session — prevents slow-client memory buildup
+        .setSendBufferSizeLimit(sendBufferSizeLimitBytes)
+
+        // Max time (ms) to wait for message send before blocking the message thread
+        .setSendTimeLimit(sendTimeLimitMs);
+}
+```
+
+**Add to `application.properties`:**
+
+```properties
+# ─── WebSocket transport limits ───────────────────────────────────────────────
+websocket.transport.message-size-limit=${WS_MESSAGE_SIZE_LIMIT:262144}
+websocket.transport.send-buffer-size-limit=${WS_SEND_BUFFER_LIMIT:524288}
+websocket.transport.send-time-limit=${WS_SEND_TIME_LIMIT:10000}
+```
+
+**Verify:**
+```
+STOMP frame > 256KB → connection closed by server (not heap-exhausted)
+Normal notification frame (~1KB) → delivered normally (regression)
+Slow client stalled for > 10s → send timeout fires, session closed
+All three limits wired via @Value — not hardcoded
+```
+
+---
+
+## MEDIUM-2 · WebSocketConfig — SockJS Profile Toggle
+
+**File:** `infrastructure/websocket/WebSocketConfig.java`  
+**Issue:** `.withSockJS()` registered unconditionally. In production, SockJS adds xhr-streaming and JSONP downgrade transports that increase CORS attack surface. Native WebSocket is the correct prod transport.
+
+**Read `registerStompEndpoints` first** — verify the current allowed origins config binding and endpoint path before modifying.
+
+```java
+@Value("${websocket.sockjs.enabled:true}")
+private boolean sockJsEnabled;
+
+@Override
+public void registerStompEndpoints(StompEndpointRegistry registry) {
+    StompWebSocketEndpointRegistration endpoint = registry
+        .addEndpoint("/ws")
+        .setAllowedOriginPatterns(allowedOriginsConfig.split(","));
+        // allowedOriginsConfig — verify @Value binding name from existing code
+
+    if (sockJsEnabled) {
+        endpoint.withSockJS();
+        // Local dev: SockJS for broader browser/tooling compatibility
+    }
+    // Prod: native WebSocket only — no SockJS xhr/jsonp downgrade paths
+}
+```
+
+**Add to `application.properties`:**
+
+```properties
+# ─── WebSocket SockJS ─────────────────────────────────────────────────────────
+websocket.sockjs.enabled=${WS_SOCKJS_ENABLED:true}
+```
+
+**Add to `application-prod.properties`:**
+
+```properties
+websocket.sockjs.enabled=false
+```
+
+**Frontend note (document in RUNBOOK.md):** The React frontend must use `new SockJS(url)` locally and `new WebSocket(url)` in production. This is a one-line client-side change — document before any React WebSocket code is written.
+
+**Verify:**
+```
+Local profile: SockJS polling transports available at /ws
+Prod profile: native WebSocket only — SockJS endpoint returns 404
+websocket.sockjs.enabled=false in application-prod.properties
+```
+
+---
+
+## Security Startup Validator
+
+**Check first:** Verify whether `SecurityStartupValidator.java` already exists from PRD-Security-Auth-Hardening. If it does, skip this section entirely.
+
+**File:** `infrastructure/config/SecurityStartupValidator.java` (new, if not already present)
+
+**Why non-optional:** A misconfigured `CORS_ALLOWED_ORIGINS=*` in prod silently passes all property checks and only becomes visible when an attacker discovers it. This validator fails fast at startup with a clear error — before any traffic is served.
+
+```java
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityStartupValidator {
+
+    @Value("${app.cors.allowed-origins:}")
+    private String corsAllowedOrigins;
+
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
+
+    @Value("${security.token.fingerprinting-enabled:false}")
+    private boolean fingerprintingEnabled;
+
+    @PostConstruct
+    public void validate() {
+        List<String> violations = new ArrayList<>();
+
+        // CORS: must be set, must not be wildcard
+        if (corsAllowedOrigins.isBlank()) {
+            violations.add("app.cors.allowed-origins must be set in production " +
+                "(CORS_ALLOWED_ORIGINS env var is empty)");
+        }
+        Arrays.stream(corsAllowedOrigins.split(","))
+            .map(String::trim)
+            .filter(o -> o.equals("*") || o.equals("*://*"))
+            .findAny()
+            .ifPresent(wildcard -> violations.add(
+                "app.cors.allowed-origins must not contain wildcard '*' in production. " +
+                "Current value: " + corsAllowedOrigins));
+
+        // Cookie security flag
+        if (!cookieSecure) {
+            violations.add("app.cookie.secure must be true in production");
+        }
+
+        // Token fingerprinting
+        if (!fingerprintingEnabled) {
+            violations.add(
+                "security.token.fingerprinting-enabled must be true in production");
+        }
+
+        if (!violations.isEmpty()) {
+            String message = "PRODUCTION SECURITY MISCONFIGURATION:\n" +
+                String.join("\n", violations.stream()
+                    .map(v -> "  - " + v)
+                    .toList());
+            log.error(message);
+            throw new IllegalStateException(message);
+        }
+
+        log.info("Security startup validation passed (prod profile)");
+    }
+}
+```
+
+**`@Profile("prod")`** — only executes in production. Local dev with `app.cookie.secure=false` does not trigger this validator. Application does not start if any violation is found — ops cannot accidentally deploy a broken security config.
+
+**Verify:**
+```
+Prod profile + CORS_ALLOWED_ORIGINS=* → startup failure with clear error message
+Prod profile + empty CORS_ALLOWED_ORIGINS → startup failure
+Prod profile + wildcard pattern *://* → startup failure
+Prod profile + all correct settings → starts normally, logs "Security startup validation passed"
+Local profile + any settings → validator not executed (no failure)
+```
+
+---
+
+## RUNBOOK.md Additions
+
+Add these entries to `orchestration/RUNBOOK.md`:
+
+```markdown
+## WebSocket Scaling Checklist
+
+### WS Tickets — Redis Migration (when horizontally scaling)
+WsTicketService stores tickets in Caffeine cache (node-local).
+On multi-node: a ticket issued by instance A may fail CONNECT on instance B.
+
+When horizontal scaling is enabled:
+  Replace Caffeine with Redis in WsTicketService:
+  Key: reviewflow:wsticket:{ticketId}
+  TTL: ticket validity window (e.g. 30 seconds)
+  Use RedisTemplate.opsForValue().setIfAbsent() + getAndDelete() for one-time use
+  Redis infrastructure already in place (PRD-19) — estimated 1-day migration.
+
+### SockJS Client Toggle (for React frontend)
+Local dev:  new SockJS(url)   — SockJS client required
+Production: new WebSocket(url) — native WebSocket only
+Controlled by: websocket.sockjs.enabled (true=local, false=prod)
+Must be handled before any React WebSocket code is written.
+
+### Per-STOMP Frame Rate Limit (deferred)
+No @MessageMapping exists in the codebase — all messaging goes through REST API.
+If @MessageMapping is ever added:
+  Add a per-session Bucket4j token bucket to the inbound channel interceptor
+  BEFORE the endpoint is used in production.
+  No rate limit on STOMP frames is acceptable only while no @MessageMapping exists.
+
+### System Messages Schema (deferred)
+When system-authored messages are implemented:
+  Add message_type ENUM('USER', 'SYSTEM') to messages table via new migration
+  sender_id becomes nullable for SYSTEM type
+  Do not implement until @MessageMapping paths exist
+```
+
+---
+
+## Verification Checklist
+
+Run in full before opening the PR.
+
+### HIGH — Force Disconnect
+```
+[ ] Force logout: /queue/session-revoked pushed to target user
+[ ] Force logout: all WS sessions closed with CloseStatus 1008 POLICY_VIOLATION
+[ ] Force logout: reconnect attempt → 401 (token invalid)
+[ ] Force logout: token revocation happens BEFORE transport close (ordering)
+[ ] ForceLogoutEvent listener uses @TransactionalEventListener(AFTER_COMMIT)
+[ ] No active WS sessions: force logout completes without error
+[ ] IOException on session close: WARN logged, continues to next session
+```
+
+### MEDIUM — Transport Limits
+```
+[ ] STOMP frame > 256KB → server closes connection
+[ ] Normal ~1KB notification frame → delivered normally (regression)
+[ ] Slow client stalled > 10s → send timeout fires, session closed
+[ ] messageSizeLimitBytes wired via @Value (not hardcoded)
+[ ] sendBufferSizeLimitBytes wired via @Value (not hardcoded)
+[ ] sendTimeLimitMs wired via @Value (not hardcoded)
+```
+
+### MEDIUM — SockJS Toggle
+```
+[ ] Local profile: SockJS transports available at /ws
+[ ] Prod profile: native WebSocket only, SockJS endpoint returns 404
+[ ] websocket.sockjs.enabled=false in application-prod.properties
+[ ] WebSocket still functional in prod with native transport
+```
+
+### Security Startup Validator
+```
+[ ] Prod profile + CORS_ALLOWED_ORIGINS=* → startup failure with clear message
+[ ] Prod profile + empty CORS → startup failure
+[ ] Prod profile + *://* pattern → startup failure
+[ ] Prod profile + all correct settings → starts normally
+[ ] Local profile → validator not executed
+[ ] SecurityStartupValidator annotated @Profile("prod")
+```
+
+### Already Covered — Verify in Other PRDs
+```
+[ ] SUBSCRIBE to /user/{otherId}/queue → rejected (PRD-Security-Auth-Hardening HIGH-4)
+[ ] 31st ws-ticket request/15min → 429 (PRD-RateLimit-Hardening HIGH-2)
+[ ] CORS: app.cors.allowed-origins set correctly in prod (PRD-Security-Auth-Hardening CRITICAL-1)
+```
+
+### Regression
+```
+[ ] Normal WebSocket CONNECT still works (local + prod)
+[ ] Notification delivery still works after transport limit changes
+[ ] Force logout does not affect other users' sessions
+[ ] RUNBOOK.md updated with all three deferred items
+```
+
+---
+
+## Summary of All Changed Files
+
+| File | Change |
+|---|---|
+| `WebSocketForceDisconnectListener.java` | Four-step sequence: push notify → hard close with `CloseStatus.POLICY_VIOLATION` via `SimpUserRegistry` + `SubProtocolWebSocketHandler`; `@TransactionalEventListener(AFTER_COMMIT)` |
+| `WebSocketConfig.java` | `configureWebSocketTransport()` override with `@Value`-backed size/time limits; SockJS conditional on `websocket.sockjs.enabled` property |
+| `application.properties` | WS transport limit properties; `websocket.sockjs.enabled=true` (default) |
+| `application-prod.properties` | `websocket.sockjs.enabled=false` |
+| `SecurityStartupValidator.java` | New — `@Profile("prod")` `@PostConstruct` validator: CORS wildcard check, cookie.secure, fingerprinting |
+| `orchestration/RUNBOOK.md` | WS tickets Redis migration path; SockJS client toggle note; per-STOMP rate limit deferred note; system messages schema deferred note |

--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,17 @@
+# Local Terraform working directory and state — never commit
+.terraform/
+*.tfstate
+*.tfstate.*
+.terraform.tfstate.lock.info
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc
+
+# Sensitive variable files (if created locally)
+*.auto.tfvars
+secrets.tfvars

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/TERRAFORM_RUNBOOK.md
+++ b/terraform/TERRAFORM_RUNBOOK.md
@@ -1,0 +1,267 @@
+# ReviewFlow — Terraform Infrastructure
+
+**Provider:** AWS (`ca-central-1`)  
+**State:** S3 backend (`reviewflow-terraform-state-ca`) + DynamoDB lock (`reviewflow-terraform-locks`)  
+**Environments:** `staging` + `prod` via separate `.tfvars`  
+**DNS:** Cloudflare (managed manually — not in Terraform)  
+**Last updated:** May 2026
+
+---
+
+## Directory Structure
+
+```
+terraform/
+├── main.tf                          ← Root — wires all modules together
+├── variables.tf                     ← Root variable definitions
+├── outputs.tf                       ← Root outputs (IPs, URLs, next steps)
+├── environments/
+│   ├── staging/staging.tfvars       ← Staging-specific values
+│   └── prod/prod.tfvars             ← Production-specific values
+└── modules/
+    ├── ec2/                         ← EC2 instance + Elastic IP
+    │   ├── main.tf
+    │   ├── variables.tf
+    │   ├── outputs.tf
+    │   └── templates/
+    │       └── user_data.sh.tpl     ← First-boot bootstrap script
+    ├── ecr/                         ← ECR repository + lifecycle policy
+    ├── iam/                         ← EC2 role + CI/CD user + policies
+    ├── s3/                          ← S3 bucket + encryption + CORS + lifecycle
+    ├── security-groups/             ← EC2 security group (ingress/egress rules)
+    └── cloudwatch/                  ← Log groups + 10 alarms + dashboard + SNS
+```
+
+---
+
+## What Terraform Manages
+
+| Resource | Module | Notes |
+|---|---|---|
+| EC2 t3.micro | `ec2` | Amazon Linux 2023, Docker pre-installed via user_data |
+| Elastic IP | `ec2` | Stable IP — Cloudflare DNS never needs updating after restart |
+| Security Group | `security-groups` | Ports 22, 80, 443, 8081/8082 |
+| S3 bucket | `s3` | `reviewflow-storage`, encrypted, versioned, lifecycle rules |
+| ECR repository | `ecr` | `reviewflow`, scan on push, lifecycle policy |
+| EC2 IAM role | `iam` | S3 + CloudWatch + ECR pull — no hardcoded keys on EC2 |
+| CI/CD IAM user | `iam` | ECR push/pull only — keys output for GitHub Secrets |
+| CloudWatch log groups | `cloudwatch` | `/reviewflow/application` + `/reviewflow/security` |
+| SNS alert topic | `cloudwatch` | Email alerts to `alert_email` |
+| 10 CloudWatch alarms | `cloudwatch` | CPU, memory, disk, status, errors, auth failures, rate limits, blocked uploads, 5xx, health check |
+| CloudWatch dashboard | `cloudwatch` | 6-widget operational overview |
+
+## What Terraform Does NOT Manage
+
+| Resource | Where it lives | Why |
+|---|---|---|
+| Cloudflare DNS records | Cloudflare dashboard | Manual — DNS provider is not AWS |
+| `.env` file on EC2 | EC2 manually | Contains secrets — never in Terraform state |
+| MySQL data | EC2 Docker volume | Stateful data — destroy would wipe student records |
+| GitHub Secrets | GitHub UI | Not AWS resources |
+| SSL certificate | Cloudflare (auto) | Cloudflare proxying provides TLS termination |
+| Domain registration | Cloudflare | Not AWS |
+
+---
+
+## Bootstrap Status — What Already Exists
+
+The following resources were created manually before Terraform.
+**Do NOT recreate them.** Terraform will use them exactly as they are.
+
+| Resource | Name | Status |
+|---|---|---|
+| S3 state bucket | `reviewflow-terraform-state-ca` | ✅ Already created |
+| DynamoDB lock table | `reviewflow-terraform-locks` | ✅ Already created |
+| EC2 key pair (staging) | `reviewflow-staging` | ✅ Already created |
+| EC2 key pair (prod) | `reviewflow-prod` | ✅ Already created |
+
+### Verify before first apply
+
+Run these to confirm everything is accessible before touching Terraform:
+
+```bash
+# Confirm state bucket is reachable
+aws s3 ls s3://reviewflow-terraform-state-ca
+
+# Confirm DynamoDB lock table exists
+aws dynamodb describe-table \
+  --table-name reviewflow-terraform-locks \
+  --region ca-central-1 \
+  --query 'Table.TableStatus'
+# Expected output: "ACTIVE"
+
+# Confirm both key pairs exist
+aws ec2 describe-key-pairs \
+  --key-names reviewflow-staging reviewflow-prod \
+  --region ca-central-1 \
+  --query 'KeyPairs[].KeyName'
+# Expected output: ["reviewflow-prod", "reviewflow-staging"]
+```
+
+### Verify and harden state bucket (do this once if not already done)
+
+```bash
+# Check versioning — should return "Enabled"
+aws s3api get-bucket-versioning \
+  --bucket reviewflow-terraform-state-ca \
+  --query 'Status'
+
+# If not enabled:
+aws s3api put-bucket-versioning \
+  --bucket reviewflow-terraform-state-ca \
+  --versioning-configuration Status=Enabled
+
+# Check encryption
+aws s3api get-bucket-encryption \
+  --bucket reviewflow-terraform-state-ca
+
+# If not set:
+aws s3api put-bucket-encryption \
+  --bucket reviewflow-terraform-state-ca \
+  --server-side-encryption-configuration \
+  '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+
+# Block all public access (critical — state contains sensitive outputs)
+aws s3api put-public-access-block \
+  --bucket reviewflow-terraform-state-ca \
+  --public-access-block-configuration \
+  "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+```
+
+---
+
+## Usage
+
+### Staging — First Run
+
+```bash
+cd terraform/
+
+# Step 1 — Initialise (first time only)
+# Downloads providers, connects to S3 backend
+terraform init
+
+# Expected output:
+# Successfully configured the backend "s3"!
+# Terraform has been successfully initialized!
+
+# Step 2 — Preview what Terraform will create
+terraform plan -var-file="environments/staging/staging.tfvars"
+
+# Step 3 — Apply
+terraform apply -var-file="environments/staging/staging.tfvars"
+
+# Step 4 — Read outputs (add these to GitHub Secrets immediately)
+terraform output ec2_public_ip                   # → EC2_HOST_STAGING in GitHub Secrets
+terraform output ecr_repository_url              # → used in docker-compose.prod.yml
+terraform output -raw ci_user_access_key_id      # → AWS_ACCESS_KEY_ID in GitHub Secrets
+terraform output -raw ci_user_secret_access_key  # → AWS_SECRET_ACCESS_KEY in GitHub Secrets
+```
+
+### Production
+
+```bash
+cd terraform/
+
+# Use a separate workspace to keep staging and prod state isolated
+terraform workspace new prod
+terraform workspace select prod
+
+terraform plan -var-file="environments/prod/prod.tfvars"
+terraform apply -var-file="environments/prod/prod.tfvars"
+```
+
+---
+
+## After First terraform apply — Checklist
+
+```
+[ ] terraform output next_steps — read the printed instructions
+
+[ ] Add to GitHub Secrets:
+    AWS_ACCESS_KEY_ID     = terraform output -raw ci_user_access_key_id
+    AWS_SECRET_ACCESS_KEY = terraform output -raw ci_user_secret_access_key
+    EC2_HOST_STAGING      = terraform output ec2_public_ip (staging workspace)
+    EC2_HOST_PROD         = terraform output ec2_public_ip (prod workspace)
+
+[ ] Update Cloudflare DNS:
+    staging.reviewflowlms.com → A → staging Elastic IP (Cloudflare proxy ON)
+    reviewflowlms.com         → A → prod Elastic IP    (Cloudflare proxy ON)
+
+[ ] SSH into EC2 and create .env:
+    ssh -i ~/.ssh/reviewflow-staging.pem ec2-user@{EC2_IP}
+    cp /opt/reviewflow/.env.example /opt/reviewflow/.env
+    nano /opt/reviewflow/.env
+    # Fill in: DB_PASSWORD, JWT_SECRET, HASHIDS_SALT,
+    #          RESEND_SMTP_PASSWORD, SENTRY_DSN, and all other values
+
+[ ] Confirm SNS email subscription:
+    Check inbox for AWS SNS confirmation email
+    Click "Confirm subscription" — alarms won't fire until confirmed
+
+[ ] Trigger first deploy from GitHub Actions:
+    Actions → CD — Deploy → Run workflow → staging
+
+[ ] Verify deployment:
+    curl https://staging.reviewflowlms.com/actuator/health
+    # Expected: {"status":"UP","components":{...}}
+```
+
+---
+
+## Key Design Decisions
+
+**Why Elastic IP:**
+EC2 instances get a new public IP on every stop/start. Without an Elastic IP, Cloudflare DNS would need manual updating after every restart. Elastic IP is free when attached to a running instance — costs $0.005/hr only when detached.
+
+**Why `prevent_destroy` on S3:**
+The S3 bucket contains student submissions, PDFs, and avatars. `terraform destroy` must never wipe this data. `prevent_destroy = true` makes Terraform refuse to delete the bucket — a deliberate friction point that requires removing the lifecycle block before destruction.
+
+**Why `ignore_changes` on EC2 AMI:**
+Amazon Linux releases new AMIs regularly. Without `ignore_changes = [ami]`, the next `terraform apply` after a new AMI release would replace the running EC2 instance, destroying the app. AMI updates are handled by launching a new instance, not in-place replacement.
+
+**Why separate key pairs per environment:**
+If `reviewflow-staging` is compromised, it cannot access production. Separate keys = separate blast radius.
+
+**Why the CI user only gets ECR permissions:**
+EC2 deploys happen via SSH in GitHub Actions — the SSH key is the auth mechanism. The CI IAM user only needs ECR push/pull. Giving it EC2 permissions would be overprivileged.
+
+**Why 10 CloudWatch alarms specifically:**
+CloudWatch free tier includes exactly 10 alarms. The 10 chosen cover: infrastructure health (CPU, memory, disk, instance status), application health (5xx, errors, health check), and security signals (auth failures, rate limits, blocked uploads).
+
+---
+
+## Staging vs Production Differences
+
+| Config | Staging | Production |
+|---|---|---|
+| `app_port` | 8081 | 8082 |
+| `instance_type` | t3.micro | t3.micro (→ t3.small at first client) |
+| `log_retention_days` | 14 | 30 |
+| `disable_api_termination` | false | true |
+| EC2 key pair | `reviewflow-staging` | `reviewflow-prod` |
+| ECR image tag prefix | `staging-{sha}` | `prod-{date}-{sha}` |
+| Cloudflare DNS | `staging.reviewflowlms.com` | `reviewflowlms.com` |
+
+Both environments run on the **same EC2 instance** on different ports.
+MySQL runs once, shared — two separate databases (`reviewflow_staging`, `reviewflow_prod`).
+
+---
+
+## Destroying Infrastructure (when needed)
+
+```bash
+# Staging — safe to destroy specific modules
+terraform destroy -var-file="environments/staging/staging.tfvars" \
+  -target=module.ec2 \
+  -target=module.cloudwatch
+
+# NEVER run full terraform destroy on production without:
+# 1. MySQL dump first:
+ssh -i ~/.ssh/reviewflow-prod.pem ec2-user@{EC2_IP}
+docker exec mysql mysqldump -u root -p reviewflow > /opt/reviewflow/backup-$(date +%Y%m%d).sql
+
+# 2. The S3 bucket has prevent_destroy = true — it will block full destroy.
+#    To actually remove the bucket, remove the lifecycle block from modules/s3/main.tf first.
+#    This is deliberate — student data should never be accidentally destroyed.
+```

--- a/terraform/environments/prod/prod.tfvars
+++ b/terraform/environments/prod/prod.tfvars
@@ -1,0 +1,27 @@
+# ─────────────────────────────────────────────
+# ReviewFlow — Production Environment
+#
+# Usage:
+#   terraform init
+#   terraform plan -var-file="environments/prod/prod.tfvars"
+#   terraform apply -var-file="environments/prod/prod.tfvars"
+# ─────────────────────────────────────────────
+
+environment    = "prod"
+aws_region     = "ca-central-1"
+
+# EC2
+instance_type  = "t3.micro"             # Upgrade to t3.small when first client signs
+ec2_key_name   = "reviewflow-prod"      # Separate key pair from staging
+app_port       = 8082                   # Different port from staging on same EC2
+
+# S3
+s3_bucket_name = "reviewflow-storage"
+
+# ECR — images tagged prod-{date}-{sha}
+ecr_repository_name    = "reviewflow"
+ecr_image_retain_count = 10             # Keep all prod images (safety)
+
+# CloudWatch
+alert_email        = "roqeeb@reviewflowlms.com"    # Replace with your email
+log_retention_days = 30                             # 30 days app, 90 days security (overridden in module)

--- a/terraform/environments/staging/staging.tfvars
+++ b/terraform/environments/staging/staging.tfvars
@@ -1,0 +1,28 @@
+# ─────────────────────────────────────────────
+# ReviewFlow — Staging Environment
+#
+# Usage:
+#   terraform init
+#   terraform plan -var-file="environments/staging/staging.tfvars"
+#   terraform apply -var-file="environments/staging/staging.tfvars"
+# ─────────────────────────────────────────────
+
+environment    = "staging"
+aws_region     = "ca-central-1"
+
+# EC2
+instance_type  = "t3.micro"
+ec2_key_name   = "reviewflow-staging"   # Name of key pair in AWS — create before apply
+app_port       = 8081
+
+# S3 — staging uses same bucket with environment prefix in keys
+# S3 key structure: submissions/{env}/{hashedAssignmentId}/...
+s3_bucket_name = "reviewflow-storage"
+
+# ECR — shared repository, images tagged staging-{sha}
+ecr_repository_name    = "reviewflow"
+ecr_image_retain_count = 10
+
+# CloudWatch
+alert_email        = "olamidefabregas26@gmail.com"    # Replace with your email
+log_retention_days = 14                             # Shorter retention for staging

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,137 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # ─────────────────────────────────────────────
+  # Remote state — S3 backend + DynamoDB lock
+  # The state bucket and lock table are the ONLY
+  # resources created manually before Terraform runs.
+  # Everything else is managed by Terraform.
+  #
+  # Bootstrap status (as of May 2026):
+  #   ✅ reviewflow-terraform-state-ca   — S3 state bucket (already created)
+  #   ✅ reviewflow-terraform-locks      — DynamoDB lock table (already created)
+  #   ✅ reviewflow-staging              — EC2 key pair (already created)
+  #   ✅ reviewflow-prod                 — EC2 key pair (already created)
+  #
+  # These were created manually. Do NOT recreate them.
+  # Run: terraform init  (first time only — downloads providers, sets backend)
+  # ─────────────────────────────────────────────
+  backend "s3" {
+    bucket         = "reviewflow-terraform-state-ca"
+    key            = "reviewflow/terraform.tfstate"
+    region         = "ca-central-1"
+    encrypt        = true
+    use_lockfile = true
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = "ReviewFlow"
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+      Owner       = "roqeeb-olamide-ayorinde"
+    }
+  }
+}
+
+# ─────────────────────────────────────────────
+# Data sources
+# ─────────────────────────────────────────────
+
+# Latest Amazon Linux 2023 AMI — always current
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Current AWS account ID — used in IAM policies
+data "aws_caller_identity" "current" {}
+
+# ─────────────────────────────────────────────
+# Modules
+# ─────────────────────────────────────────────
+
+module "iam" {
+  source = "./modules/iam"
+
+  environment    = var.environment
+  aws_region     = var.aws_region
+  account_id     = data.aws_caller_identity.current.account_id
+  s3_bucket_name = var.s3_bucket_name
+  ecr_repo_name  = var.ecr_repository_name
+}
+
+module "s3" {
+  source = "./modules/s3"
+
+  environment    = var.environment
+  s3_bucket_name = var.s3_bucket_name
+  aws_region     = var.aws_region
+}
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  environment        = var.environment
+  repository_name    = var.ecr_repository_name
+  image_retain_count = var.ecr_image_retain_count
+}
+
+module "security_groups" {
+  source = "./modules/security-groups"
+
+  environment = var.environment
+  vpc_id      = var.vpc_id
+  app_port    = var.app_port
+}
+
+module "ec2" {
+  source = "./modules/ec2"
+
+  environment          = var.environment
+  ami_id               = data.aws_ami.amazon_linux_2023.id
+  instance_type        = var.instance_type
+  key_name             = var.ec2_key_name
+  security_group_ids   = [module.security_groups.app_sg_id]
+  iam_instance_profile = module.iam.ec2_instance_profile_name
+  app_port             = var.app_port
+  aws_region           = var.aws_region
+  ecr_repository_url   = module.ecr.repository_url
+  s3_bucket_name       = var.s3_bucket_name
+
+  depends_on = [module.iam, module.security_groups]
+}
+
+module "cloudwatch" {
+  source = "./modules/cloudwatch"
+
+  environment       = var.environment
+  aws_region        = var.aws_region
+  ec2_instance_id   = module.ec2.instance_id
+  app_port          = var.app_port
+  alert_email       = var.alert_email
+  log_retention_days = var.log_retention_days
+
+  depends_on = [module.ec2]
+}

--- a/terraform/modules/cloudwatch/main.tf
+++ b/terraform/modules/cloudwatch/main.tf
@@ -1,0 +1,377 @@
+# ─────────────────────────────────────────────
+# Module: CloudWatch
+# Creates:
+#   - Log groups (application + security)
+#   - SNS topic for alerts
+#   - 10 CloudWatch Alarms (free tier limit)
+#   - CloudWatch Dashboard
+# ─────────────────────────────────────────────
+
+# ── Log Groups ────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "application" {
+  name              = "/reviewflow/application"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    Name = "reviewflow-application-logs"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "security" {
+  name              = "/reviewflow/security"
+  retention_in_days = 90  # Security logs kept longer regardless of env setting
+
+  tags = {
+    Name = "reviewflow-security-logs"
+  }
+}
+
+# ── SNS Topic for Alerts ──────────────────────
+
+resource "aws_sns_topic" "alerts" {
+  name = "reviewflow-${var.environment}-alerts"
+
+  tags = {
+    Name = "reviewflow-${var.environment}-alerts"
+  }
+}
+
+resource "aws_sns_topic_subscription" "email" {
+  topic_arn = aws_sns_topic.alerts.arn
+  protocol  = "email"
+  endpoint  = var.alert_email
+}
+
+# ── CloudWatch Alarms (10 free tier) ──────────
+# Priority order — most critical first.
+# All alarm → SNS → email.
+
+# 1. CPU > 80% for 5 minutes
+resource "aws_cloudwatch_metric_alarm" "cpu_high" {
+  alarm_name          = "reviewflow-${var.environment}-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "EC2 CPU > 80% for 10 minutes"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = var.ec2_instance_id
+  }
+}
+
+# 2. Memory > 85%
+# Requires CloudWatch Agent (installed in user_data)
+resource "aws_cloudwatch_metric_alarm" "memory_high" {
+  alarm_name          = "reviewflow-${var.environment}-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "mem_used_percent"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 85
+  alarm_description   = "EC2 memory > 85% — risk of OOM on t3.micro"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+}
+
+# 3. Disk > 80%
+resource "aws_cloudwatch_metric_alarm" "disk_high" {
+  alarm_name          = "reviewflow-${var.environment}-disk-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "disk_used_percent"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "EC2 disk > 80% — Docker images or logs filling up"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+}
+
+# 4. Instance status check failed
+resource "aws_cloudwatch_metric_alarm" "instance_status" {
+  alarm_name          = "reviewflow-${var.environment}-instance-status"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "EC2 instance status check failed — hardware or OS issue"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = var.ec2_instance_id
+  }
+}
+
+# 5. ERROR log rate > 10 per minute
+resource "aws_cloudwatch_metric_alarm" "error_rate" {
+  alarm_name          = "reviewflow-${var.environment}-error-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "ErrorCount"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 10
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "Application ERROR log rate > 10/min — check application logs"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+}
+
+# Log metric filter — counts ERROR lines in application log
+resource "aws_cloudwatch_log_metric_filter" "error_count" {
+  name           = "reviewflow-${var.environment}-error-count"
+  pattern        = "[timestamp, level=ERROR, ...]"
+  log_group_name = aws_cloudwatch_log_group.application.name
+
+  metric_transformation {
+    name          = "ErrorCount"
+    namespace     = "ReviewFlow/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+# 6. Auth failure rate > 20 per minute (brute force indicator)
+resource "aws_cloudwatch_metric_alarm" "auth_failures" {
+  alarm_name          = "reviewflow-${var.environment}-auth-failures"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "AuthFailureCount"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 20
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "Auth failure rate > 20/min — possible brute force attack"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "auth_failures" {
+  name           = "reviewflow-${var.environment}-auth-failure-filter"
+  pattern        = "[timestamp, level, logger, message=\"*authentication failed*\", ...]"
+  log_group_name = aws_cloudwatch_log_group.security.name
+
+  metric_transformation {
+    name          = "AuthFailureCount"
+    namespace     = "ReviewFlow/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+# 7. Rate limiter triggered > 50 per minute
+resource "aws_cloudwatch_metric_alarm" "rate_limit_hits" {
+  alarm_name          = "reviewflow-${var.environment}-rate-limit"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "RateLimitHits"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 50
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "Rate limiter triggered > 50/min — possible abuse"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "rate_limit" {
+  name           = "reviewflow-${var.environment}-rate-limit-filter"
+  pattern        = "[timestamp, level, logger, message=\"*rate limit exceeded*\", ...]"
+  log_group_name = aws_cloudwatch_log_group.security.name
+
+  metric_transformation {
+    name          = "RateLimitHits"
+    namespace     = "ReviewFlow/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+# 8. Blocked file upload attempts
+resource "aws_cloudwatch_metric_alarm" "blocked_uploads" {
+  alarm_name          = "reviewflow-${var.environment}-blocked-uploads"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "BlockedUploadCount"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 5
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "FileSecurityValidator blocked > 5 uploads in 5 min — possible malicious upload attempt"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "blocked_uploads" {
+  name           = "reviewflow-${var.environment}-blocked-upload-filter"
+  pattern        = "[timestamp, level, logger, message=\"*file validation failed*\", ...]"
+  log_group_name = aws_cloudwatch_log_group.security.name
+
+  metric_transformation {
+    name          = "BlockedUploadCount"
+    namespace     = "ReviewFlow/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+# 9. 5xx response rate > 5 per minute
+resource "aws_cloudwatch_metric_alarm" "http_5xx" {
+  alarm_name          = "reviewflow-${var.environment}-5xx-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "Http5xxCount"
+  namespace           = "ReviewFlow/${var.environment}"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = 5
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "5xx error rate > 5/min — application errors"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "http_5xx" {
+  name           = "reviewflow-${var.environment}-5xx-filter"
+  pattern        = "[timestamp, level=ERROR, logger=\"*Controller*\", ...]"
+  log_group_name = aws_cloudwatch_log_group.application.name
+
+  metric_transformation {
+    name          = "Http5xxCount"
+    namespace     = "ReviewFlow/${var.environment}"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+# 10. Health check endpoint down
+# Polls /actuator/health via synthetic monitor
+# Uses CloudWatch Synthetics canary (replaces UptimeRobot for AWS-native monitoring)
+resource "aws_cloudwatch_metric_alarm" "health_check" {
+  alarm_name          = "reviewflow-${var.environment}-health-check"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "SuccessPercent"
+  namespace           = "CloudWatchSynthetics"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 100
+  treat_missing_data  = "breaching"
+  alarm_description   = "Health check canary failing — app may be down"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    CanaryName = "reviewflow-${var.environment}-health"
+  }
+}
+
+# ── CloudWatch Dashboard ──────────────────────
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "ReviewFlow-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "CPU Utilization"
+          region  = var.aws_region
+          period  = 300
+          stat    = "Average"
+          view    = "timeSeries"
+          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", var.ec2_instance_id]]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Memory Used %"
+          region  = var.aws_region
+          period  = 300
+          stat    = "Average"
+          view    = "timeSeries"
+          metrics = [["ReviewFlow/${var.environment}", "mem_used_percent"]]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Error Rate"
+          region  = var.aws_region
+          period  = 60
+          stat    = "Sum"
+          view    = "timeSeries"
+          metrics = [["ReviewFlow/${var.environment}", "ErrorCount"]]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Auth Failures"
+          region  = var.aws_region
+          period  = 60
+          stat    = "Sum"
+          view    = "timeSeries"
+          metrics = [["ReviewFlow/${var.environment}", "AuthFailureCount"]]
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title   = "Blocked Upload Attempts"
+          region  = var.aws_region
+          period  = 300
+          stat    = "Sum"
+          view    = "timeSeries"
+          metrics = [["ReviewFlow/${var.environment}", "BlockedUploadCount"]]
+        }
+      },
+      {
+        type   = "log"
+        x      = 12
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title  = "Recent Errors"
+          region = var.aws_region
+          view   = "table"
+          query  = "SOURCE '/reviewflow/application' | fields @timestamp, @message | filter @message like /ERROR/ | sort @timestamp desc | limit 20"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/cloudwatch/outputs.tf
+++ b/terraform/modules/cloudwatch/outputs.tf
@@ -1,0 +1,4 @@
+output "log_group_app" { value = aws_cloudwatch_log_group.application.name }
+output "log_group_security" { value = aws_cloudwatch_log_group.security.name }
+output "sns_topic_arn" { value = aws_sns_topic.alerts.arn }
+output "dashboard_name" { value = aws_cloudwatch_dashboard.main.dashboard_name }

--- a/terraform/modules/cloudwatch/variables.tf
+++ b/terraform/modules/cloudwatch/variables.tf
@@ -1,0 +1,6 @@
+variable "environment" { type = string }
+variable "aws_region" { type = string }
+variable "ec2_instance_id" { type = string }
+variable "app_port" { type = number }
+variable "alert_email" { type = string }
+variable "log_retention_days" { type = number }

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,65 @@
+# ─────────────────────────────────────────────
+# Module: EC2
+# Creates the EC2 instance with:
+#   - IAM instance profile attached
+#   - Security group applied
+#   - User data script for first-boot setup
+#   - Docker + Docker Compose installed
+#   - CloudWatch agent installed
+# ─────────────────────────────────────────────
+
+resource "aws_instance" "app" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.key_name
+  vpc_security_group_ids = var.security_group_ids
+  iam_instance_profile   = var.iam_instance_profile
+
+  # Root volume — 20GB is enough for OS + Docker images + logs
+  root_block_device {
+    volume_type           = "gp3"
+    volume_size           = 30
+    delete_on_termination = true
+    encrypted             = true
+
+    tags = {
+      Name = "reviewflow-${var.environment}-root"
+    }
+  }
+
+  # User data — runs once on first boot
+  # Installs Docker, Docker Compose, CloudWatch Agent
+  # Creates app directory structure
+  user_data = base64encode(templatefile("${path.module}/templates/user_data.sh.tpl", {
+    environment        = var.environment
+    app_port           = var.app_port
+    aws_region         = var.aws_region
+    ecr_repository_url = var.ecr_repository_url
+    s3_bucket_name     = var.s3_bucket_name
+  }))
+
+  # Prevent accidental termination of production instance
+  disable_api_termination = var.environment == "prod" ? true : false
+
+  tags = {
+    Name = "reviewflow-${var.environment}"
+  }
+
+  lifecycle {
+    # Never replace the instance if only the AMI changes
+    # (would destroy the running app)
+    # To update AMI: drain → terminate → apply
+    ignore_changes = [ami, user_data]
+  }
+}
+
+# Elastic IP — keeps the IP stable across stop/start
+# Required so Cloudflare DNS doesn't need updating after EC2 restarts
+resource "aws_eip" "app" {
+  instance = aws_instance.app.id
+  domain   = "vpc"
+
+  tags = {
+    Name = "reviewflow-${var.environment}-eip"
+  }
+}

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,12 @@
+output "instance_id" {
+  value = aws_instance.app.id
+}
+
+output "public_ip" {
+  description = "Elastic IP — stable across restarts"
+  value       = aws_eip.app.public_ip
+}
+
+output "public_dns" {
+  value = aws_eip.app.public_dns
+}

--- a/terraform/modules/ec2/templates/user_data.sh.tpl
+++ b/terraform/modules/ec2/templates/user_data.sh.tpl
@@ -1,0 +1,205 @@
+#!/bin/bash
+# ─────────────────────────────────────────────
+# ReviewFlow EC2 First-Boot Setup Script
+# Environment: ${environment}
+# Runs once on instance launch via user_data.
+# All subsequent deploys use the CI/CD pipeline.
+# ─────────────────────────────────────────────
+
+set -euxo pipefail
+exec > >(tee /var/log/user-data.log) 2>&1
+
+echo "=== ReviewFlow EC2 Bootstrap — ${environment} ==="
+echo "Started at: $(date)"
+
+# ── System update ────────────────────────────
+dnf update -y
+dnf install -y \
+  docker \
+  git \
+  curl \
+  wget \
+  unzip \
+  jq \
+  mysql \
+  htop
+
+# ── Docker ───────────────────────────────────
+systemctl start docker
+systemctl enable docker
+usermod -aG docker ec2-user
+
+# ── Docker Compose ───────────────────────────
+DOCKER_COMPOSE_VERSION="2.24.0"
+curl -SL "https://github.com/docker/compose/releases/download/v$${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+  -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+ln -sf /usr/local/bin/docker-compose /usr/bin/docker-compose
+
+# ── AWS CLI v2 ───────────────────────────────
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
+
+# ── CloudWatch Agent ─────────────────────────
+wget -q https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm \
+  -O /tmp/cloudwatch-agent.rpm
+rpm -U /tmp/cloudwatch-agent.rpm
+rm /tmp/cloudwatch-agent.rpm
+
+# CloudWatch agent config
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << 'CWCONFIG'
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/reviewflow/application.log",
+            "log_group_name": "/reviewflow/application",
+            "log_stream_name": "${environment}-{instance_id}",
+            "retention_in_days": 30,
+            "timezone": "UTC"
+          },
+          {
+            "file_path": "/var/log/reviewflow/security.log",
+            "log_group_name": "/reviewflow/security",
+            "log_stream_name": "${environment}-{instance_id}",
+            "retention_in_days": 90,
+            "timezone": "UTC"
+          }
+        ]
+      }
+    }
+  },
+  "metrics": {
+    "namespace": "ReviewFlow/${environment}",
+    "metrics_collected": {
+      "cpu": {
+        "measurement": ["cpu_usage_idle", "cpu_usage_user", "cpu_usage_system"],
+        "metrics_collection_interval": 60
+      },
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 60
+      },
+      "disk": {
+        "measurement": ["disk_used_percent"],
+        "metrics_collection_interval": 300,
+        "resources": ["/"]
+      }
+    }
+  }
+}
+CWCONFIG
+
+systemctl start amazon-cloudwatch-agent
+systemctl enable amazon-cloudwatch-agent
+
+# ── App directory structure ───────────────────
+mkdir -p /opt/reviewflow
+mkdir -p /var/log/reviewflow
+chown -R ec2-user:ec2-user /opt/reviewflow
+chown -R ec2-user:ec2-user /var/log/reviewflow
+
+# ── docker-compose.prod.yml placeholder ──────
+# Real file is deployed by CI/CD pipeline.
+# This placeholder prevents docker-compose errors
+# if someone runs it before first deploy.
+cat > /opt/reviewflow/docker-compose.prod.yml << 'COMPOSE'
+# This file is managed by the CI/CD pipeline.
+# Do not edit manually — changes will be overwritten on deploy.
+# To update: push to main branch and the pipeline will redeploy.
+version: '3.8'
+services:
+  app:
+    image: ${ecr_repository_url}:staging-latest
+    ports:
+      - "${app_port}:8081"
+    env_file:
+      - /opt/reviewflow/.env
+    volumes:
+      - /var/log/reviewflow:/var/log/reviewflow
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8081/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+      MYSQL_DATABASE: reviewflow
+      MYSQL_USER: reviewflow
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+    volumes:
+      - mysql_data:/var/lib/mysql
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+volumes:
+  mysql_data:
+COMPOSE
+
+chown ec2-user:ec2-user /opt/reviewflow/docker-compose.prod.yml
+
+# ── .env placeholder ─────────────────────────
+# NEVER committed to git.
+# Populated manually after EC2 launch.
+cat > /opt/reviewflow/.env.example << 'ENVEXAMPLE'
+# Copy this to .env and fill in real values
+# Never commit .env to version control
+
+SPRING_PROFILES_ACTIVE=prod
+
+# Database
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/reviewflow
+SPRING_DATASOURCE_USERNAME=reviewflow
+SPRING_DATASOURCE_PASSWORD=
+
+# Auth
+JWT_SECRET=
+JWT_ACCESS_TOKEN_EXPIRY_MINUTES=15
+JWT_REFRESH_TOKEN_EXPIRY_DAYS=7
+
+# Hashids — NEVER change after first deployment
+HASHIDS_SALT=
+HASHIDS_MIN_LENGTH=8
+
+# S3
+AWS_S3_BUCKET=${s3_bucket_name}
+AWS_REGION=${aws_region}
+# No AWS keys needed — EC2 role handles auth
+
+# Email (Resend SMTP)
+RESEND_SMTP_HOST=smtp.resend.com
+RESEND_SMTP_PORT=587
+RESEND_SMTP_USERNAME=resend
+RESEND_SMTP_PASSWORD=
+MAIL_FROM=noreply@reviewflowlms.com
+
+# Security headers
+SECURITY_HEADERS_HSTS_ENABLED=true
+SECURITY_HEADERS_HSTS_MAX_AGE=31536000
+SECURITY_HEADERS_HSTS_INCLUDE_SUBDOMAINS=true
+
+# CORS
+CORS_ALLOWED_ORIGINS=https://reviewflowlms.com
+
+# Monitoring
+CLOUDWATCH_METRICS_ENABLED=false
+ENVEXAMPLE
+
+chown ec2-user:ec2-user /opt/reviewflow/.env.example
+
+echo "=== Bootstrap complete at: $(date) ==="
+echo "=== Next steps: ==="
+echo "  1. Copy /opt/reviewflow/.env.example to /opt/reviewflow/.env"
+echo "  2. Fill in all values in .env"
+echo "  3. Trigger first deploy from GitHub Actions"

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,10 @@
+variable "environment" { type = string }
+variable "ami_id" { type = string }
+variable "instance_type" { type = string }
+variable "key_name" { type = string }
+variable "security_group_ids" { type = list(string) }
+variable "iam_instance_profile" { type = string }
+variable "app_port" { type = number }
+variable "aws_region" { type = string }
+variable "ecr_repository_url" { type = string }
+variable "s3_bucket_name" { type = string }

--- a/terraform/modules/ecr/main.tf
+++ b/terraform/modules/ecr/main.tf
@@ -1,0 +1,75 @@
+# ─────────────────────────────────────────────
+# Module: ECR
+# Single repository for ReviewFlow Docker images.
+# Images tagged:
+#   staging-{sha}     on every merge to main
+#   prod-{date}-{sha} on production deploy
+#   staging-latest    always points to newest staging
+#   prod-latest       always points to newest prod
+# ─────────────────────────────────────────────
+
+resource "aws_ecr_repository" "reviewflow" {
+  name                 = var.repository_name
+  image_tag_mutability = "MUTABLE"  # Required for 'latest' tag updates
+
+  # Scan images on push — catches OS-level CVEs in base image
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = {
+    Name = var.repository_name
+  }
+}
+
+# Lifecycle policy — keep last N images per tag prefix
+# Prevents unbounded storage growth
+resource "aws_ecr_lifecycle_policy" "reviewflow" {
+  repository = aws_ecr_repository.reviewflow.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        # Keep last 10 staging images
+        rulePriority = 1
+        description  = "Keep last ${var.image_retain_count} staging images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["staging-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = var.image_retain_count
+        }
+        action = { type = "expire" }
+      },
+      {
+        # Keep all prod images — never auto-expire production
+        # Manual cleanup only via nightly.yml ECR cleanup job
+        rulePriority = 2
+        description  = "Keep all prod images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["prod-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 999
+        }
+        action = { type = "expire" }
+      },
+      {
+        # Clean up untagged images after 1 day
+        rulePriority = 3
+        description  = "Remove untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}

--- a/terraform/modules/ecr/outputs.tf
+++ b/terraform/modules/ecr/outputs.tf
@@ -1,0 +1,2 @@
+output "repository_url" { value = aws_ecr_repository.reviewflow.repository_url }
+output "repository_arn" { value = aws_ecr_repository.reviewflow.arn }

--- a/terraform/modules/ecr/variables.tf
+++ b/terraform/modules/ecr/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" { type = string }
+variable "repository_name" { type = string }
+variable "image_retain_count" { type = number }

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,180 @@
+# ─────────────────────────────────────────────
+# Module: IAM
+# Creates:
+#   1. EC2 instance role (S3 + CloudWatch + ECR pull)
+#   2. CI/CD IAM user (ECR push/pull only)
+#   3. All policies — principle of least privilege
+# ─────────────────────────────────────────────
+
+# ── EC2 Instance Role ────────────────────────
+
+resource "aws_iam_role" "ec2_role" {
+  name = "ReviewFlowEC2Role-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+
+  tags = {
+    Name = "ReviewFlowEC2Role-${var.environment}"
+  }
+}
+
+# EC2 → S3 (reviewflow-storage only)
+resource "aws_iam_policy" "ec2_s3" {
+  name        = "ReviewFlowEC2S3Policy-${var.environment}"
+  description = "Allows EC2 to read/write ReviewFlow S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObject",
+          "s3:ListBucket",
+          "s3:GetObjectVersion",
+          "s3:PutObjectAcl"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.s3_bucket_name}",
+          "arn:aws:s3:::${var.s3_bucket_name}/*"
+        ]
+      }
+    ]
+  })
+}
+
+# EC2 → CloudWatch (logs + metrics)
+resource "aws_iam_policy" "ec2_cloudwatch" {
+  name        = "ReviewFlowEC2CloudWatchPolicy-${var.environment}"
+  description = "Allows EC2 CloudWatch agent to ship logs and metrics"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudwatch:PutMetricData",
+          "cloudwatch:GetMetricData",
+          "cloudwatch:ListMetrics",
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams",
+          "logs:DescribeLogGroups"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# EC2 → ECR (pull images only — not push)
+resource "aws_iam_policy" "ec2_ecr" {
+  name        = "ReviewFlowEC2ECRPolicy-${var.environment}"
+  description = "Allows EC2 to pull images from ECR"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach all policies to EC2 role
+resource "aws_iam_role_policy_attachment" "ec2_s3" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.ec2_s3.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_cloudwatch" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.ec2_cloudwatch.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_ecr" {
+  role       = aws_iam_role.ec2_role.name
+  policy_arn = aws_iam_policy.ec2_ecr.arn
+}
+
+# Instance profile — what actually attaches to EC2
+resource "aws_iam_instance_profile" "ec2_profile" {
+  name = "ReviewFlowEC2Profile-${var.environment}"
+  role = aws_iam_role.ec2_role.name
+}
+
+# ── CI/CD IAM User ────────────────────────────
+# Used by GitHub Actions for ECR push/pull + image cleanup.
+# No console access. Access keys only.
+# Scoped to ECR only — EC2 deploys via SSH, not IAM.
+
+resource "aws_iam_user" "ci_user" {
+  name = "reviewflow-ci-user"
+  path = "/ci/"
+
+  tags = {
+    Purpose = "GitHub Actions CI/CD - ECR access only"
+  }
+}
+
+resource "aws_iam_policy" "ci_ecr" {
+  name        = "ReviewFlowCIECRPolicy"
+  description = "GitHub Actions CI/CD - ECR push/pull and image cleanup"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:PutImage",
+          "ecr:InitiateLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:CompleteLayerUpload",
+          "ecr:DescribeImages",
+          "ecr:BatchDeleteImage"
+        ]
+        Resource = "arn:aws:ecr:${var.aws_region}:${var.account_id}:repository/${var.ecr_repo_name}"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "ci_ecr" {
+  user       = aws_iam_user.ci_user.name
+  policy_arn = aws_iam_policy.ci_ecr.arn
+}
+
+# Access keys for CI user — output to be added to GitHub Secrets
+# NOTE: Terraform stores these in state. State is encrypted in S3.
+resource "aws_iam_access_key" "ci_user" {
+  user = aws_iam_user.ci_user.name
+}

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,15 @@
+output "ec2_instance_profile_name" {
+  value = aws_iam_instance_profile.ec2_profile.name
+}
+
+output "ci_user_access_key_id" {
+  description = "Add to GitHub Secrets as AWS_ACCESS_KEY_ID"
+  value       = aws_iam_access_key.ci_user.id
+  sensitive   = true
+}
+
+output "ci_user_secret_access_key" {
+  description = "Add to GitHub Secrets as AWS_SECRET_ACCESS_KEY"
+  value       = aws_iam_access_key.ci_user.secret
+  sensitive   = true
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,5 @@
+variable "environment" { type = string }
+variable "aws_region" { type = string }
+variable "account_id" { type = string }
+variable "s3_bucket_name" { type = string }
+variable "ecr_repo_name" { type = string }

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -1,0 +1,127 @@
+# ─────────────────────────────────────────────
+# Module: S3
+# ReviewFlow file storage bucket.
+# Key structure (enforced by application, not S3):
+#   submissions/{hashedAssignmentId}/{hashedOwnerId}/v{n}/{filename}
+#   pdfs/{hashedEvaluationId}/report.pdf
+#   avatars/{hashedUserId}/avatar.{ext}
+#   materials/{hashedCourseId}/{hashedMaterialId}/{filename}
+#   messages/{hashedConversationId}/{hashedMessageId}/{filename}
+# ─────────────────────────────────────────────
+
+resource "aws_s3_bucket" "reviewflow" {
+  bucket = var.s3_bucket_name
+
+  # Prevent accidental destruction of a bucket with student data
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = {
+    Name = var.s3_bucket_name
+  }
+}
+
+# Block all public access — files served via pre-signed URLs only
+resource "aws_s3_bucket_public_access_block" "reviewflow" {
+  bucket = aws_s3_bucket.reviewflow.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Versioning — protects against accidental overwrites
+# Submissions are versioned at the application layer (v1, v2, v3 in key)
+# S3 versioning is an additional safety net
+resource "aws_s3_bucket_versioning" "reviewflow" {
+  bucket = aws_s3_bucket.reviewflow.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Server-side encryption — AES-256
+resource "aws_s3_bucket_server_side_encryption_configuration" "reviewflow" {
+  bucket = aws_s3_bucket.reviewflow.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# CORS — required for pre-signed URL direct uploads from browser
+# When React frontend is built, uploads will go directly to S3
+# via pre-signed URLs, not through the Spring Boot backend
+resource "aws_s3_bucket_cors_configuration" "reviewflow" {
+  bucket = aws_s3_bucket.reviewflow.id
+
+  cors_rule {
+    allowed_headers = ["Content-Type", "Content-Disposition", "Authorization"]
+    allowed_methods = ["GET", "PUT", "POST"]
+    allowed_origins = [
+      "https://reviewflowlms.com",
+      "https://staging.reviewflowlms.com",
+      "http://localhost:3000",  # React dev server
+      "http://localhost:5173"   # Vite dev server
+    ]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3600
+  }
+}
+
+# Lifecycle rules — manage storage costs
+resource "aws_s3_bucket_lifecycle_configuration" "reviewflow" {
+  bucket = aws_s3_bucket.reviewflow.id
+
+  # Move old submission versions to cheaper storage after 90 days
+  rule {
+    id     = "submission-noncurrent-versions"
+    status = "Enabled"
+
+    filter {
+      prefix = "submissions/"
+    }
+
+    noncurrent_version_transition {
+      noncurrent_days = 90
+      storage_class   = "STANDARD_IA"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 365
+    }
+  }
+
+  # Clean up incomplete multipart uploads after 7 days
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  # PDF reports: move to IA after 180 days
+  rule {
+    id     = "pdf-reports-lifecycle"
+    status = "Enabled"
+
+    filter {
+      prefix = "pdfs/"
+    }
+
+    transition {
+      days          = 180
+      storage_class = "STANDARD_IA"
+    }
+  }
+}

--- a/terraform/modules/s3/outputs.tf
+++ b/terraform/modules/s3/outputs.tf
@@ -1,0 +1,2 @@
+output "bucket_name" { value = aws_s3_bucket.reviewflow.bucket }
+output "bucket_arn" { value = aws_s3_bucket.reviewflow.arn }

--- a/terraform/modules/s3/variables.tf
+++ b/terraform/modules/s3/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" { type = string }
+variable "s3_bucket_name" { type = string }
+variable "aws_region" { type = string }

--- a/terraform/modules/security-groups/main.tf
+++ b/terraform/modules/security-groups/main.tf
@@ -1,0 +1,80 @@
+# ─────────────────────────────────────────────
+# Module: Security Groups
+# Principle of least privilege — only open
+# what ReviewFlow actually needs.
+# ─────────────────────────────────────────────
+
+# Look up default VPC if none specified
+data "aws_vpc" "selected" {
+  id      = var.vpc_id != "" ? var.vpc_id : null
+  default = var.vpc_id == "" ? true : null
+}
+
+resource "aws_security_group" "app" {
+  name        = "reviewflow-${var.environment}-app"
+  description = "ReviewFlow ${var.environment} application security group"
+  vpc_id      = data.aws_vpc.selected.id
+
+  # ── Inbound ──────────────────────────────
+
+  # HTTPS — public traffic
+  ingress {
+    description = "HTTPS from internet"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTP — redirect to HTTPS (Cloudflare handles this)
+  ingress {
+    description = "HTTP from internet (Cloudflare redirect)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # App port — Cloudflare proxies to this port
+  # Cloudflare IP ranges only in production would be ideal,
+  # but 0.0.0.0/0 is acceptable while Cloudflare proxying is enabled
+  ingress {
+    description = "Spring Boot application"
+    from_port   = var.app_port
+    to_port     = var.app_port
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # SSH — restricted to your IP only
+  # IMPORTANT: Replace 0.0.0.0/0 with your actual IP before apply
+  # Use: curl ifconfig.me to get your current IP
+  # Then set: ssh_cidr = ["YOUR.IP.HERE/32"]
+  ingress {
+    description = "SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.ssh_allowed_cidrs
+  }
+
+  # ── Outbound ─────────────────────────────
+
+  # All outbound allowed — EC2 needs to reach:
+  #   - ECR (image pulls)
+  #   - S3 (file storage)
+  #   - CloudWatch (logs + metrics)
+  #   - Resend SMTP (port 587)
+  #   - NVD for OWASP scans (not on EC2 but in CI)
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "reviewflow-${var.environment}-app-sg"
+  }
+}

--- a/terraform/modules/security-groups/outputs.tf
+++ b/terraform/modules/security-groups/outputs.tf
@@ -1,0 +1,3 @@
+output "app_sg_id" {
+  value = aws_security_group.app.id
+}

--- a/terraform/modules/security-groups/variables.tf
+++ b/terraform/modules/security-groups/variables.tf
@@ -1,0 +1,8 @@
+variable "environment" { type = string }
+variable "vpc_id" { type = string }
+variable "app_port" { type = number }
+variable "ssh_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks allowed SSH access. Restrict to your IP: [\"YOUR.IP/32\"]"
+  default     = ["0.0.0.0/0"]  # CHANGE THIS before production apply
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,91 @@
+# ─────────────────────────────────────────────
+# ReviewFlow — Root Outputs
+# Values printed after terraform apply.
+# Add these to GitHub Secrets after first apply.
+# ─────────────────────────────────────────────
+
+output "ec2_public_ip" {
+  description = "Public IP of the EC2 instance — add to GitHub Secrets as EC2_HOST_STAGING or EC2_HOST_PROD"
+  value       = module.ec2.public_ip
+}
+
+output "ec2_public_dns" {
+  description = "Public DNS of the EC2 instance"
+  value       = module.ec2.public_dns
+}
+
+output "ecr_repository_url" {
+  description = "ECR repository URL — used in docker-compose.prod.yml and CI/CD pipeline"
+  value       = module.ecr.repository_url
+}
+
+output "s3_bucket_name" {
+  description = "S3 bucket name for ReviewFlow file storage"
+  value       = module.s3.bucket_name
+}
+
+output "s3_bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = module.s3.bucket_arn
+}
+
+output "cloudwatch_log_group_app" {
+  description = "CloudWatch log group for application logs"
+  value       = module.cloudwatch.log_group_app
+}
+
+output "cloudwatch_log_group_security" {
+  description = "CloudWatch log group for security logs"
+  value       = module.cloudwatch.log_group_security
+}
+
+output "sns_topic_arn" {
+  description = "SNS topic ARN for alerts — subscribe additional emails if needed"
+  value       = module.cloudwatch.sns_topic_arn
+}
+
+output "ec2_instance_id" {
+  description = "EC2 instance ID — used in CloudWatch dashboards"
+  value       = module.ec2.instance_id
+}
+
+output "next_steps" {
+  description = "What to do after terraform apply"
+  value       = <<-EOT
+
+    ── After terraform apply ──────────────────────────────────
+
+    1. Add EC2 IP to GitHub Secrets:
+       EC2_HOST_STAGING = ${module.ec2.public_ip}   (staging)
+       EC2_HOST_PROD    = ${module.ec2.public_ip}   (prod)
+
+    2. Update Cloudflare DNS:
+       staging.reviewflowlms.com → A → ${module.ec2.public_ip}
+       reviewflowlms.com         → A → ${module.ec2.public_ip}
+
+    3. SSH into EC2 and run first-time setup:
+       ssh -i ~/.ssh/${var.ec2_key_name}.pem ec2-user@${module.ec2.public_ip}
+       sudo /opt/reviewflow/setup.sh
+
+    4. Trigger first deploy from GitHub Actions:
+       Actions → CD — Deploy → Run workflow → staging
+
+    5. Verify:
+       curl https://staging.reviewflowlms.com/actuator/health
+
+    ──────────────────────────────────────────────────────────
+  EOT
+}
+output "ci_user_access_key_id" {
+  description = "Add to GitHub Secrets as AWS_ACCESS_KEY_ID"
+  value       = module.iam.ci_user_access_key_id
+  sensitive   = true
+}
+
+output "ci_user_secret_access_key" {
+  description = "Add to GitHub Secrets as AWS_SECRET_ACCESS_KEY"
+  value       = module.iam.ci_user_secret_access_key
+  sensitive   = true
+}
+
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,97 @@
+# ─────────────────────────────────────────────
+# ReviewFlow — Root Variables
+# All values supplied via environment-specific
+# .tfvars files in environments/staging/ or
+# environments/prod/
+# ─────────────────────────────────────────────
+
+variable "environment" {
+  description = "Deployment environment (staging or prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["staging", "prod"], var.environment)
+    error_message = "Environment must be 'staging' or 'prod'."
+  }
+}
+
+variable "aws_region" {
+  description = "AWS region for all resources"
+  type        = string
+  default     = "ca-central-1"
+}
+
+variable "vpc_id" {
+  description = "VPC ID to deploy into. Uses default VPC if not specified."
+  type        = string
+  default     = ""
+}
+
+# ─── EC2 ───────────────────────────────────
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.micro"
+
+  validation {
+    condition     = contains(["t3.micro", "t3.small", "t3.medium"], var.instance_type)
+    error_message = "Instance type must be t3.micro, t3.small, or t3.medium."
+  }
+}
+
+variable "ec2_key_name" {
+  description = "Name of the EC2 key pair for SSH access"
+  type        = string
+}
+
+variable "app_port" {
+  description = "Port the Spring Boot application listens on"
+  type        = number
+  default     = 8081
+
+  validation {
+    condition     = var.app_port > 1024 && var.app_port < 65535
+    error_message = "App port must be between 1024 and 65535."
+  }
+}
+
+# ─── S3 ────────────────────────────────────
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket for ReviewFlow file storage"
+  type        = string
+  default     = "reviewflow-storage"
+}
+
+# ─── ECR ───────────────────────────────────
+
+variable "ecr_repository_name" {
+  description = "Name of the ECR repository for Docker images"
+  type        = string
+  default     = "reviewflow"
+}
+
+variable "ecr_image_retain_count" {
+  description = "Number of images to retain per environment tag prefix"
+  type        = number
+  default     = 10
+}
+
+# ─── CloudWatch ────────────────────────────
+
+variable "alert_email" {
+  description = "Email address for CloudWatch alarm notifications"
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days"
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = contains([1, 3, 5, 7, 14, 30, 60, 90, 120, 180, 365], var.log_retention_days)
+    error_message = "Log retention must be a valid CloudWatch retention value."
+  }
+}


### PR DESCRIPTION
## Summary
- Add version-controlled AWS Terraform stack under `terraform/` (EC2, ECR, IAM, S3, security groups, CloudWatch) with staging/prod tfvars, provider lock file, runbook, and `.gitignore` for local state.
- Include pending docs: PRD-15 course roster spec and websocket-hardening agent guide.
- Branch also carries security/observability/rate-limit/file-handening work from `fix/security-hardening` (auth fixes, WebSocket hardening, ClamAV, transaction boundaries, Redis rate limits, V36 pending S3 deletions, and related tests).

## Test plan
- [x] Review `terraform/TERRAFORM_RUNBOOK.md` and confirm S3 backend + DynamoDB lock bootstrap matches AWS account
- [ ] Run `terraform init` and `terraform plan -var-file=environments/staging/staging.tfvars` from `terraform/`
- [ ] Verify no `.terraform/` or `*.tfstate` files are committed
- [ ] Run `./mvnw test` on branch (Redis required for some integration tests)
- [ ] After merge, update local clone remote URL if needed (`Reviewflow` repo rename)


Made with [Cursor](https://cursor.com)